### PR TITLE
Fix bug related to path_dir_splitter

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -221,7 +221,7 @@ end
 @static if Sys.iswindows() && VERSION < v"1.3"
     if VERSION < v"1.2"
         function _splitdir_nodrive(a::String, b::String)
-            m = match(Base.path_dir_splitter,b)
+            m = match(r"^(.*?)([/\\]+)([^/\\]*)$",b)
             m === nothing && return (a,b)
             a = string(a, isempty(m.captures[1]) ? m.captures[2][1] : m.captures[1])
             a, String(m.captures[3])


### PR DESCRIPTION
For some reason `path_dir_splitter` is not defined on julia 1.1.1.

For now I just copied it, that seems an easy fix.