### PR TITLE
documentChanges is nullable

### DIFF
--- a/src/protocol/configuration.jl
+++ b/src/protocol/configuration.jl
@@ -1,7 +1,7 @@
 
 
 @json_read mutable struct WorkspaceEditCapabilities
-    documentChanges::Bool
+    documentChanges::Union{Nothing,Bool}
 end
 
 @json_read mutable struct Capabilities


### PR DESCRIPTION
`documentChanges` can be null according to specs. This is needed for other lsp clients, like [lsp4intellij](https://github.com/ballerina-platform/lsp4intellij)