### PR TITLE
Fix _splitdir_nodrive error

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -219,16 +219,13 @@ function get_identifier(x, offset, pos = 0)
 end
 
 @static if Sys.iswindows() && VERSION < v"1.3"
-    if VERSION < v"1.2"
-        function _splitdir_nodrive(a::String, b::String)
-            m = match(r"^(.*?)([/\\]+)([^/\\]*)$",b)
-            m === nothing && return (a,b)
-            a = string(a, isempty(m.captures[1]) ? m.captures[2][1] : m.captures[1])
-            a, String(m.captures[3])
-        end
-    else
-        _splitdir_nodrive = Base._splitdir_nodrive
+    function _splitdir_nodrive(a::String, b::String)
+        m = match(r"^(.*?)([/\\]+)([^/\\]*)$",b)
+        m === nothing && return (a,b)
+        a = string(a, isempty(m.captures[1]) ? m.captures[2][1] : m.captures[1])
+        a, String(m.captures[3])
     end
+    
     function _dirname(path::String)
         m = match(r"^([^\\]+:|\\\\[^\\]+\\[^\\]+|\\\\\?\\UNC\\[^\\]+\\[^\\]+|\\\\\?\\[^\\]+:|)(.*)$"s, path)
         a, b = String(m.captures[1]), String(m.captures[2])


### PR DESCRIPTION
I don't understand why the previous construction doesn't work, but this seems to work and fixes things on julia 1.2.0.

Fixes https://github.com/julia-vscode/julia-vscode/issues/831 (maybe).