### PR TITLE
Update languageserver.sh to support Julia 1.0

### DIFF
--- a/contrib/languageserver.sh
+++ b/contrib/languageserver.sh
@@ -24,7 +24,7 @@ while [[ $# -gt 0 ]]
 done
 
 $JULIABIN --startup-file=no --history-file=no -e \
-    "using LanguageServer; server = LanguageServer.LanguageServerInstance(STDIN, STDOUT, $DEBUG); server.runlinter = true; run(server);" \
+    "using LanguageServer; import SymbolServer; server = LanguageServer.LanguageServerInstance(stdin, stdout, $DEBUG); server.runlinter = true; run(server);" \
     <&0 >&1 &
 
 PID=$!


### PR DESCRIPTION
STDIN and STDOUT are lowercase now, and you get "ERROR: Couldn't load core stores" (see https://github.com/julia-vscode/LanguageServer.jl/issues/375) without SymbolServer.