### PR TITLE
Force recalc of line offsets for each document change

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -127,7 +127,6 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didChange")},DidCha
         for tdcce in r.params.contentChanges
             applytextdocumentchanges(doc, tdcce)
         end
-        doc._line_offsets = nothing
         parse_all(doc, server)
     end
 end
@@ -241,6 +240,7 @@ function applytextdocumentchanges(doc::Document, tdcce::TextDocumentContentChang
         editrange = get_offset(doc, tdcce.range)
         doc._content = edit_string(doc._content, editrange, tdcce.text)
     end
+    doc._line_offsets = nothing
 end
 
 function edit_string(text, editrange, edit)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using LanguageServer, CSTParser, Test, SymbolServer
-Range = LanguageServer.Range
+const LS = LanguageServer
+const Range = LanguageServer.Range
 
 @testset "LanguageServer" begin
 
@@ -7,6 +8,5 @@ include("test_document.jl")
 include("test_communication.jl")
 include("test_hover.jl")
 include("text_edit.jl")
-
 
 end

--- a/test/test_document.jl
+++ b/test/test_document.jl
@@ -50,3 +50,21 @@ s6 = "\n"
 d6 = Document("untitled", s6, false)
 @test get_line_offsets(d6) == [0,1]
 
+@testset "applytextdocumentchanges" begin
+    doc = LS.Document("file:///example/path/example.jl", "function foo()", false)
+    c1 = LS.TextDocumentContentChangeEvent(LS.Range(LS.Position(0,14), LS.Position(0,14)),
+                                        0, "\n")
+    c2 = LS.TextDocumentContentChangeEvent(LS.Range(LS.Position(1,0), LS.Position(1,0)),
+                                           0, "    ")
+    c3 = LS.TextDocumentContentChangeEvent(nothing, nothing, "println(\"Hello World\")")
+
+    LS.applytextdocumentchanges(doc, c1)
+    @test LS.get_text(doc) == "function foo()\n"
+    # Implicitly test for issue #403
+    LS.applytextdocumentchanges(doc, c2)
+    @test LS.get_text(doc) == "function foo()\n    "
+    LS.applytextdocumentchanges(doc, c3)
+    @test LS.get_text(doc) == "println(\"Hello World\")"
+    # doc currently has only one line, applying change to 2nd line should throw
+    @test_throws BoundsError LS.applytextdocumentchanges(doc, c2)
+end

--- a/test/test_document.jl
+++ b/test/test_document.jl
@@ -36,7 +36,7 @@ d2 = Document("untitled", s2, true)
 
 
 applytextdocumentchanges(d2, LanguageServer.TextDocumentContentChangeEvent(Range(1), 0, "12"))
-@test_broken get_line_offsets(d2) == [0, 8, 17]
+@test get_line_offsets(d2) == [0, 8, 17]
 
 s4 = "1234\r\nabcd"
 d4 = Document("untitled", s4, false)


### PR DESCRIPTION
Closes #403

The problem is that `Document._line_offsets` isn't updated until all changes from a particular rpc message have been processed. I think this bug hasn't been seen before because `textDocument/didChange` with multiple changes are rare in practice. There may be a more performant way of updating the offsets for each change, but this should at least fix the problem.