### PR TITLE
Fix configuration handling

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -1,9 +1,3 @@
-mutable struct LSDiagnostic{C}
-    loc::UnitRange{Int}
-    actions::Vector{Any}
-    message::String
-end
-
 mutable struct Document
     _uri::String
     path::String
@@ -12,7 +6,7 @@ mutable struct Document
     _open_in_editor::Bool
     _workspace_file::Bool
     cst::EXPR
-    diagnostics::Vector{LSDiagnostic}
+    diagnostics::Vector{Diagnostic}
     _version::Int
     _runlinter::Bool
     server

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -50,10 +50,17 @@ function Base.run(server::LanguageServerInstance)
         elseif get(message_dict, "id", 0)  == -100 && haskey(message_dict, "result")
             # set format options
             if length(message_dict["result"]) == length(fieldnames(DocumentFormat.FormatOptions)) + 1
-                try
-                    server.format_options = DocumentFormat.FormatOptions(message_dict["result"][1:end-1]...)
-                catch
-                end
+                server.format_options = DocumentFormat.FormatOptions(
+                    message_dict["result"][1]===nothing ? 0 : message_dict["result"][1],
+                    message_dict["result"][2]===nothing ? false : message_dict["result"][2],
+                    message_dict["result"][3]===nothing ? false : message_dict["result"][3],
+                    message_dict["result"][4]===nothing ? false : message_dict["result"][4],
+                    message_dict["result"][5]===nothing ? false : message_dict["result"][5],
+                    message_dict["result"][6]===nothing ? false : message_dict["result"][6],
+                    message_dict["result"][7]===nothing ? false : message_dict["result"][7],
+                    message_dict["result"][8]===nothing ? false : message_dict["result"][8],
+                    message_dict["result"][9]===nothing ? false : message_dict["result"][9],
+                    message_dict["result"][10]===nothing ? false : message_dict["result"][10])
 
                 x = message_dict["result"][end]
                 new_run_lint_value = x===nothing ? false : true

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -102,7 +102,9 @@ function process(r::JSONRPC.Request{Val{Symbol("initialized")}}, server)
         end
     end
     send(JSONRPC.Request{Val{Symbol("workspace/configuration")},ConfigurationParams}(-100, ConfigurationParams([
-        ConfigurationItem(nothing, "julia.format.$opt") for opt in fieldnames(DocumentFormat.FormatOptions)])), server)
+        (ConfigurationItem(nothing, "julia.format.$opt") for opt in fieldnames(DocumentFormat.FormatOptions))...;
+        ConfigurationItem(nothing, "julia.runLinter")
+        ])), server)
 
     write_transport_layer(server.pipe_out, JSON.json(Dict("jsonrpc" => "2.0", "id" => "278352324", "method" => "client/registerCapability", "params" => Dict("registrations" => [Dict("id"=>"28c6550c-bd7b-11e7-abc4-cec278b6b50a", "method"=>"workspace/didChangeWorkspaceFolders")]))), server.debug_mode)
 end

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -117,12 +117,9 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didChange")},DidCha
     if length(r.params.contentChanges) == 1 && !endswith(doc._uri, ".jmd") && first(r.params.contentChanges).range !== nothing
         tdcce = first(r.params.contentChanges)
         new_cst = _partial_update(doc, tdcce) 
-        ls_diags = Diagnostic[]
-        if server.runlinter && doc._runlinter
-            scopepass(getroot(doc))
-            mark_errors(doc, ls_diags)
-        end
-        send(JSONRPC.Request{Val{Symbol("textDocument/publishDiagnostics")},PublishDiagnosticsParams}(nothing, PublishDiagnosticsParams(doc._uri, ls_diags)), server)
+        scopepass(getroot(doc))
+        mark_errors(doc, doc.diagnostics)
+        publish_diagnostics(doc, server)
     else
         for tdcce in r.params.contentChanges
             applytextdocumentchanges(doc, tdcce)

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -34,16 +34,6 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeConfiguration
         (ConfigurationItem(nothing, "julia.format.$opt") for opt in fieldnames(DocumentFormat.FormatOptions))...;
         ConfigurationItem(nothing, "julia.runLinter")
         ])), server)
-
-
-    if r.params["settings"] isa Dict && haskey(r.params["settings"], "julia")
-        jsettings = r.params["settings"]["julia"]
-        if haskey(jsettings, "format")
-            for (k,v) in jsettings["format"]
-                setproperty!(server.format_options, Symbol(k), v)
-            end
-        end
-    end
 end
 
 

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -38,21 +38,6 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeConfiguration
 
     if r.params["settings"] isa Dict && haskey(r.params["settings"], "julia")
         jsettings = r.params["settings"]["julia"]
-        if haskey(jsettings, "lintIgnoreList")
-            server.ignorelist = Set(jsettings["lintIgnoreList"])
-            for (uri,doc) in server.documents
-                if is_ignored(uri, server)
-                    doc._runlinter = false
-                    clear_diagnostics(uri, server)
-                else
-                    if !doc._runlinter
-                        doc._runlinter = true
-                        append!(doc.diagnostics, L.diagnostics)
-                        publish_diagnostics(doc, server)
-                    end
-                end
-            end
-        end
         if haskey(jsettings, "format")
             for (k,v) in jsettings["format"]
                 setproperty!(server.format_options, Symbol(k), v)


### PR DESCRIPTION
This now always runs the linter, the only thing one can control is whether the messages are actually published to the client. The setting now also works again :)

Now generally fixes how configuration changes are handled, also for format options.

The second linter setting (the ignore list) was not hooked up in any case, so I just removed that.