### PR TITLE
Fix load_rootpath

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -35,11 +35,11 @@ function isjuliabasedir(path)
 end
 
 function load_rootpath(path)
+    isdir(path) &&
+    hasreadperm(path) &&
     !(path == "" || 
     path == homedir() ||
-    isjuliabasedir(path)) &&
-    isdir(path) &&
-    hasreadperm(path)
+    isjuliabasedir(path))    
 end
 
 function load_folder(wf::WorkspaceFolder, server)


### PR DESCRIPTION
This just rearranges the checks so that it first checks whether the folder exists and there are read permissions, before it calls `isjuliabasedir` (which will crash if the folder doesn't exist.

This should fix a big that came in via crash reporting.