### PR TITLE
fix file link clicking

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -119,11 +119,13 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/definition")},TextD
             end
         end
     elseif x isa EXPR && typof(x) === CSTParser.LITERAL && (kindof(x) === Tokens.STRING || kindof(x) === Tokens.TRIPLE_STRING)
-        if isfile(valof(x))
-            push!(locations, Location(filepath2uri(valof(x)), Range(0, 0, 0, 0)))
-        elseif isfile(joinpath(dirname(uri2filepath(doc._uri)), valof(x)))
-            push!(locations, Location(filepath2uri(joinpath(dirname(uri2filepath(doc._uri)), valof(x))), Range(0, 0, 0, 0)))
-        end 
+        if sizeof(valof(x)) < 256
+            if isfile(valof(x))
+                push!(locations, Location(filepath2uri(valof(x)), Range(0, 0, 0, 0)))
+            elseif isfile(joinpath(dirname(uri2filepath(doc._uri)), valof(x)))
+                push!(locations, Location(filepath2uri(joinpath(dirname(uri2filepath(doc._uri)), valof(x))), Range(0, 0, 0, 0)))
+            end
+        end
     end
     
     send(JSONRPC.Response(r.id, locations), server)


### PR DESCRIPTION
running on `isfile` on Strings longer than 255 characters is an error