### PR TITLE
Handle `nothing` received in Language Server Protocol

### DIFF
--- a/src/protocol/protocol.jl
+++ b/src/protocol/protocol.jl
@@ -49,7 +49,7 @@ macro dict_readable(arg)
                 f = :(dict[$fieldname])
             end
             if field_allows_missing(field)
-                f = :(haskey(dict,$fieldname) ? $f : missing)
+                f = :(haskey(dict,$fieldname) && !isnothing(dict[$fieldname]) ? $f : missing)
             end
             push!(fex.args, f)
         end


### PR DESCRIPTION
There exists keys in the dictionary from parsing the LanguageServerProtocol message that contain the value `nothing`. This can be changed to a `missing`.