### PR TITLE
expand single line function codeAction

### DIFF
--- a/src/protocol/basic.jl
+++ b/src/protocol/basic.jl
@@ -44,7 +44,7 @@ struct DiagnosticRelatedInformation
     message::String
 end
 
-struct Diagnostic <: Outbound
+@dict_readable struct Diagnostic <: Outbound
     range::Range
     severity::Union{Int,Missing}
     code::Union{String,Missing}

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -10,7 +10,7 @@ const serverCapabilities = ServerCapabilities(
     false,
     true,
     true,
-    false,
+    true,
     missing,
     true,
     false,


### PR DESCRIPTION
Expand single line functions codeAction. e.g.
```julia
f(a,b) = 1
f(a,b) = begin
    1
    2
end
f(a,b) = (1;2)
```
become:
```julia
function f(a,b)
    1
end
function f(a,b)
    1
    2
end
function f(a,b)
    1
    2
end
```