### PR TITLE
add alternative get_expr for hovers and definitions

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -80,7 +80,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/definition")},TextD
     locations = Location[]
     doc = server.documents[URI2(r.params.textDocument.uri)]
     offset = get_offset(doc, r.params.position)
-    x = get_expr(getcst(doc), offset)
+    x = get_expr1(getcst(doc), offset)
     if x isa EXPR && StaticLint.hasref(x)
         b = refof(x)
         if b isa SymbolServer.FunctionStore || b isa SymbolServer.DataTypeStore
@@ -172,7 +172,7 @@ function find_references(textDocument::TextDocumentIdentifier, position::Positio
     locations = Location[]
     doc = server.documents[URI2(textDocument.uri)] 
     offset = get_offset(doc, position)
-    x = get_identifier(getcst(doc), offset)
+    x = get_expr1(getcst(doc), offset)
     if x isa EXPR && StaticLint.hasref(x) && refof(x) isa StaticLint.Binding
         for r in refof(x).refs
             !(r isa EXPR) && continue

--- a/src/requests/hover.jl
+++ b/src/requests/hover.jl
@@ -5,7 +5,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/hover")},TextDocume
         return
     end
     doc = server.documents[URI2(r.params.textDocument.uri)]
-    x = get_expr(getcst(doc), get_offset(doc, r.params.position), 0, true)
+    x = get_expr1(getcst(doc), get_offset(doc, r.params.position))
     documentation = get_hover(x, "", server)
     documentation = get_fcall_position(x, documentation)
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -189,7 +189,7 @@ function get_expr1(x, offset, pos = 0)
                         return get_expr1(arg, offset, pos)
                     end
                 elseif offset == pos + arg.span
-                    return arg
+                    return get_expr1(arg, offset, pos)
                 elseif offset == pos + arg.fullspan
                 elseif pos+arg.span < offset < pos + arg.fullspan
                     return nothing

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -155,6 +155,52 @@ function get_expr(x, offset, pos = 0, ignorewhitespace = false)
     end
 end
 
+function get_expr1(x, offset, pos = 0)
+    if x.args === nothing || isempty(x.args)
+        if pos <= offset <= pos + x.span
+            return x
+        else
+            return nothing
+        end
+    else
+        for i = 1:length(x.args)
+            arg = x.args[i]
+            if pos < offset < (pos + arg.span) # def within span
+                return get_expr1(arg, offset, pos)
+            elseif arg.span == arg.fullspan
+                if offset == pos
+                    if i == 1
+                        return get_expr1(arg, offset, pos)
+                    elseif CSTParser.typof(x.args[i-1]) === CSTParser.IDENTIFIER
+                        return get_expr1(x.args[i-1], offset, pos)
+                    else
+                        return get_expr1(arg, offset, pos)
+                    end
+                else # offset == pos + arg.fullspan
+
+                end
+            else
+                if offset == pos
+                    if i == 1
+                        return get_expr1(arg, offset, pos)
+                    elseif CSTParser.typof(x.args[i-1]) === CSTParser.IDENTIFIER
+                        return get_expr1(x.args[i-1], offset, pos)
+                    else
+                        return get_expr1(arg, offset, pos)
+                    end
+                elseif offset == pos + arg.span
+                    return arg
+                elseif offset == pos + arg.fullspan
+                elseif pos+arg.span < offset < pos + arg.fullspan
+                    return nothing
+                end
+            end
+            pos += arg.fullspan
+        end
+        return nothing
+    end
+end
+
 
 function get_identifier(x, offset, pos = 0)
     if pos > offset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,22 @@
-using LanguageServer, CSTParser, Test, SymbolServer
+using Test, Sockets, LanguageServer, CSTParser, SymbolServer, SymbolServer.Pkg, StaticLint, JSON
+using LanguageServer: Document, get_text, get_offset, get_line_offsets, get_position_at, get_open_in_editor, set_open_in_editor, is_workspace_file, applytextdocumentchanges
+ssp = SymbolServerProcess()
 const LS = LanguageServer
 const Range = LanguageServer.Range
 
 @testset "LanguageServer" begin
 
+@testset "document" begin
 include("test_document.jl")
+end
+@testset "communication" begin
 include("test_communication.jl")
+end
+@testset "hover" begin
 include("test_hover.jl")
+end
+@testset "edit" begin
 include("text_edit.jl")
+end
 
 end

--- a/test/test_communication.jl
+++ b/test/test_communication.jl
@@ -1,5 +1,3 @@
-using JSON, Sockets, Pkg, SymbolServer
-
 init_request = """
 {
     "jsonrpc":"2.0",

--- a/test/test_document.jl
+++ b/test/test_document.jl
@@ -1,5 +1,3 @@
-import LanguageServer: Document, get_text, get_offset, get_line_offsets, get_position_at, get_open_in_editor, set_open_in_editor, is_workspace_file, applytextdocumentchanges
-
 s1 = """
 123456
 abcde

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -1,7 +1,5 @@
-import LanguageServer: LanguageServerInstance, Document, Pkg
-using LanguageServer, CSTParser, StaticLint, SymbolServer
-
 server = LanguageServerInstance(IOBuffer(), IOBuffer(), true, dirname(Pkg.Types.Context().env.project_file), first(Base.DEPOT_PATH))
+server.symbol_server = ssp
 @async run(server)
 t = time()
 while server.symbol_server isa Nothing && time() - t < 60
@@ -10,7 +8,6 @@ end
 
 server.runlinter = true
 LanguageServer.process(LanguageServer.parse(LanguageServer.JSONRPC.Request, JSON.parse(init_request)), server)
-
 
 function getresult(server)
     str = String(take!(server.pipe_out))

--- a/test/text_edit.jl
+++ b/test/text_edit.jl
@@ -24,9 +24,6 @@ mktempdir() do dir
         doc._line_offsets = nothing
 
         LanguageServer._partial_update(doc, tdcce)
-        # LanguageServer.applytextdocumentchanges(doc, tdcce)
-        # doc._line_offsets = nothing
-        # LanguageServer.parse_all(doc, server)
         new_cst = CSTParser.parse(LanguageServer.get_text(doc), true)
         Expr(doc.cst) == Expr(new_cst), doc.cst, new_cst
     end


### PR DESCRIPTION
get_expr1 finds the expression at a given offset, choosing an identifier when lying in between two expressions. Fixes https://github.com/julia-vscode/julia-vscode/issues/925 and some other issues where hovers weren't appearing when the cursor was at the start of an expression.

