### PR TITLE
Async symbolserver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,9 @@ URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 
 [compat]
 CSTParser = "2.1"
-DocumentFormat = "2"
+DocumentFormat = "2.0.1"
 JSON = "0.20, 0.21"
-StaticLint = "3"
+StaticLint = "3.0.1"
 Tokenize = "0.5.7"
 URIParser = "0.4.0"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StaticLint = "3"
 Tokenize = "0.5.7"
 URIParser = "0.4.0"
 julia = "1"
-SymbolServer = "2"
+SymbolServer = "3"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -77,12 +77,7 @@ function send(message, server)
     write_transport_layer(server.pipe_out, message_json, server.debug_mode)
 end
 
-"""
-    run(server::LanguageServerInstance)
-
-Run the language `server`.
-"""
-function Base.run(server::LanguageServerInstance)
+function trigger_symbolstore_reload(server::LanguageServerInstance)
     @async begin
         # TODO Add try catch handler that links into crash reporting
         ssi_ret, payload = SymbolServer.getstore(server.symbol_server, server.env_path)
@@ -91,6 +86,15 @@ function Base.run(server::LanguageServerInstance)
             push!(server.symbol_results_channel, payload)
         end
     end
+end
+
+"""
+    run(server::LanguageServerInstance)
+
+Run the language `server`.
+"""
+function Base.run(server::LanguageServerInstance)
+    trigger_symbolstore_reload(server)
     
     global T
     while true

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -58,7 +58,7 @@ mutable struct LanguageServerInstance
             depot_path, 
             SymbolServer.SymbolServerInstance(depot_path), 
             Channel(Inf),
-            Dict{String,SymbolServer.ModuleStore}(),
+            deepcopy(SymbolServer.stdlibs),
             DocumentFormat.FormatOptions(), 
             StaticLint.LintOptions()
         )

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -83,7 +83,14 @@ end
 Run the language `server`.
 """
 function Base.run(server::LanguageServerInstance)
-    SymbolServer.getstore(server.symbol_server, server.env_path, server.symbol_results_channel)
+    @async begin
+        # TODO Add try catch handler that links into crash reporting
+        ssi_ret, payload = SymbolServer.getstore(server.symbol_server, server.env_path)
+
+        if ssi_ret==:success
+            push!(server.symbol_results_channel, payload)
+        end
+    end
     
     global T
     while true

--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -80,5 +80,12 @@ JSONRPC.parse_params(::Type{Val{Symbol("julia/activateenvironment")}}, params) =
 function process(r::JSONRPC.Request{Val{Symbol("julia/activateenvironment")}}, server)
     server.env_path = r.params
 
-    SymbolServer.getstore(server.symbol_server, server.env_path, server.symbol_results_channel)
+    @async begin
+        # TODO Add try catch handler that links into crash reporting
+        ssi_ret, payload = SymbolServer.getstore(server.symbol_server, server.env_path)
+
+        if ssi_ret==:success
+            push!(server.symbol_results_channel, payload)
+        end
+    end    
 end

--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -79,39 +79,6 @@ end
 JSONRPC.parse_params(::Type{Val{Symbol("julia/activateenvironment")}}, params) = params
 function process(r::JSONRPC.Request{Val{Symbol("julia/activateenvironment")}}, server)
     server.env_path = r.params
-    server.symbol_server = StaticLint.SymbolServer.SymbolServerProcess(depot = server.depot_path, environment = server.env_path)
-    @info "Restarted symbol server"
-    StaticLint.SymbolServer.getstore(server.symbol_server)
-    @info "StaticLint store set"
-    kill(server.symbol_server)
 
-    for (uri, doc) in server.documents
-        parse_all(doc, server)
-    end
-    @info "Finished reparsing everything"
+    SymbolServer.getstore(server.symbol_server, server.env_path, server.symbol_results_channel)
 end
-
-# SymbolServer:parallel branch ################################################
-
-# function process(r::JSONRPC.Request{Val{Symbol("julia/activateenvironment")}}, server::LanguageServerInstance)
-#     _set_worker_env(r.params, server)
-# end
-
-# function _set_worker_env(env_path, server::LanguageServerInstance)
-#     wid = last(procs())
-#     server.debug_mode && @info "Activating: ", server.env_path
-#     @fetchfrom wid SymbolServer.Pkg.activate(env_path)
-
-#     server.symbol_server.context = @fetchfrom wid SymbolServer.Pkg.Types.Context()
-#     server.debug_mode && @info "New project file: ",  server.symbol_server.context.env.project_file
-
-#     missing_pkgs = SymbolServer.disc_load_project(server.symbol_server)
-#     if isempty(missing_pkgs)
-#         server.ss_task = nothing
-#     else
-#         pkg_uuids = collect(keys(missing_pkgs))
-#         server.debug_mode && @info "Missing or outdated package caches: ", collect(missing_pkgs)
-#         server.ss_task = @spawnat wid SymbolServer.cache_packages_and_save(server.symbol_server.context, pkg_uuids)
-#     end
-# end
-###############################################################################        

--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -80,12 +80,5 @@ JSONRPC.parse_params(::Type{Val{Symbol("julia/activateenvironment")}}, params) =
 function process(r::JSONRPC.Request{Val{Symbol("julia/activateenvironment")}}, server)
     server.env_path = r.params
 
-    @async begin
-        # TODO Add try catch handler that links into crash reporting
-        ssi_ret, payload = SymbolServer.getstore(server.symbol_server, server.env_path)
-
-        if ssi_ret==:success
-            push!(server.symbol_results_channel, payload)
-        end
-    end    
+    trigger_symbolstore_reload(server)
 end

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -10,7 +10,7 @@ function loadfile(server::LanguageServerInstance, path::String)
 end
 setfile(server::LanguageServerInstance, path::String, x::Document) = server.documents[URI2(filepath2uri(path))] = x
 getfile(server::LanguageServerInstance, path::String) = server.documents[URI2(filepath2uri(path))]
-getsymbolserver(server::LanguageServerInstance) = server.symbol_server.depot
+getsymbolserver(server::LanguageServerInstance) = server.symbol_store
 
 getpath(d::Document) = d.path
 function setpath(d::Document, path::String)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Test, Sockets, LanguageServer, CSTParser, SymbolServer, SymbolServer.Pkg, StaticLint, JSON
 using LanguageServer: Document, get_text, get_offset, get_line_offsets, get_position_at, get_open_in_editor, set_open_in_editor, is_workspace_file, applytextdocumentchanges
-ssp = SymbolServerProcess()
 const LS = LanguageServer
 const Range = LanguageServer.Range
 

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -1,5 +1,4 @@
 server = LanguageServerInstance(IOBuffer(), IOBuffer(), true, dirname(Pkg.Types.Context().env.project_file), first(Base.DEPOT_PATH))
-server.symbol_server = ssp
 @async run(server)
 t = time()
 while server.symbol_server isa Nothing && time() - t < 60


### PR DESCRIPTION
Complements https://github.com/julia-vscode/SymbolServer.jl/pull/72. All seems to work :)

EDIT: There is another benefit of this approach: we should be able to eventually just have the JSON RPC layer and the symbol server put their messages into the same channel, and then the main message loop can just process both messages from the client _and_ from the symbol server, without the current design that we only handle symbol server messages when something happened on the main message queue.