### PR TITLE
For large folders, only load files on demand

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -40,12 +40,29 @@ function isjuliabasedir(path)
     all(f -> f in fs, ["coreimg.jl", "coreio.jl", "inference.jl"])
 end
 
+function has_too_many_files(path, N = 5000)
+    i = 0
+    for (root, dirs, files) in walkdir(path, onerror = x->x)
+        for file in files
+            if endswith(file, ".jl")
+                i += 1
+            end
+            if i > N
+                @info "Your workspace folder has > $N Julia files, server will not try to load them."
+                return true
+            end
+        end
+    end
+    return false
+end
+
 function load_rootpath(path)
     isdir(path) &&
     hasreadperm(path) &&
-    !(path == "" || 
-    path == homedir() ||
-    isjuliabasedir(path))    
+    path != "" &&
+    path != homedir() &&
+    !isjuliabasedir(path) &&
+    !has_too_many_files(path)
 end
 
 function load_folder(wf::WorkspaceFolder, server)


### PR DESCRIPTION
Fix for https://github.com/julia-vscode/julia-vscode/issues/919.
- Checks for number of julia files in workspace folders, it > 5000 doesn't attempt to load them.
- When loading files not already loaded to the server will attempt to find and load parent files that include the initial file