### PR TITLE
Send all messages via a queue

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -122,7 +122,7 @@ function process(r::JSONRPC.Request{Val{Symbol("initialized")}}, server)
     end
     request_julia_config(server)
 
-    write_transport_layer(server.pipe_out, JSON.json(Dict("jsonrpc" => "2.0", "id" => "278352324", "method" => "client/registerCapability", "params" => Dict("registrations" => [Dict("id"=>"28c6550c-bd7b-11e7-abc4-cec278b6b50a", "method"=>"workspace/didChangeWorkspaceFolders")]))), server.debug_mode)
+    send(Dict("jsonrpc" => "2.0", "id" => "278352324", "method" => "client/registerCapability", "params" => Dict("registrations" => [Dict("id"=>"28c6550c-bd7b-11e7-abc4-cec278b6b50a", "method"=>"workspace/didChangeWorkspaceFolders")])), server)
 end
 
 

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -92,7 +92,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didChange")},DidCha
     end
     doc = server.documents[URI2(r.params.textDocument.uri)]
     if r.params.textDocument.version < doc._version
-        write_transport_layer(server.pipe_out, JSON.json(Dict("jsonrpc" => "2.0", "method" => "julia/getFullText", "params" => doc._uri)), server.debug_mode)
+        send(Dict("jsonrpc" => "2.0", "method" => "julia/getFullText", "params" => doc._uri), server)
         return
     end
     doc._version = r.params.textDocument.version

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -1,4 +1,4 @@
-server = LanguageServerInstance(IOBuffer(), IOBuffer(), true, dirname(Pkg.Types.Context().env.project_file), first(Base.DEPOT_PATH))
+server = LanguageServerInstance(IOBuffer(), IOBuffer(), false, dirname(Pkg.Types.Context().env.project_file), first(Base.DEPOT_PATH))
 @async run(server)
 t = time()
 while server.symbol_server isa Nothing && time() - t < 60
@@ -31,19 +31,23 @@ LanguageServer.process(LanguageServer.JSONRPC.Request{Val{Symbol("textDocument/d
 doc = server.documents[LanguageServer.URI2("testdoc")]
 LanguageServer.parse_all(doc, server)
 
+sleep(1)
 # clear init output
 take!(server.pipe_out)
 
 LanguageServer.process(LanguageServer.parse(LanguageServer.JSONRPC.Request, JSON.parse("""{"jsonrpc":"2.0","id":1,"method":"textDocument/hover","params":{"textDocument":{"uri":"testdoc"},"position":{"line":3,"character":11}}}""")), server)
+sleep(1)
 res = getresult(server)
 
 @test res["value"] == StaticLint.CoreTypes.Float64.doc
 
 LanguageServer.process(LanguageServer.parse(LanguageServer.JSONRPC.Request, JSON.parse("""{"jsonrpc":"2.0","id":1,"method":"textDocument/hover","params":{"textDocument":{"uri":"testdoc"},"position":{"line":7,"character":12}}}""")), server)
+sleep(1)
 res = getresult(server)
 @test occursin(r"c::testtype", res["value"])
 
 
 LanguageServer.process(LanguageServer.parse(LanguageServer.JSONRPC.Request, JSON.parse("""{"jsonrpc":"2.0","id":1,"method":"textDocument/hover","params":{"textDocument":{"uri":"testdoc"},"position":{"line":9,"character":1}}}""")), server)
+sleep(1)
 res = getresult(server)
 @test res["value"] == "Closes `ModuleH` expression."

--- a/test/text_edit.jl
+++ b/test/text_edit.jl
@@ -1,4 +1,4 @@
-server = LanguageServer.LanguageServerInstance(IOBuffer(), IOBuffer(), true, dirname(Pkg.Types.Context().env.project_file), first(Base.DEPOT_PATH))
+server = LanguageServer.LanguageServerInstance(IOBuffer(), IOBuffer(), false, dirname(Pkg.Types.Context().env.project_file), first(Base.DEPOT_PATH))
 @async run(server)
 t = time()
 while server.symbol_server isa Nothing && time() - t < 60


### PR DESCRIPTION
The idea is that we now never call `write_transport_layer` anywhere, other than in the thread for message sending. Instead, we use `send` everywhere. The benefit is that we can call that from any thread, without messing up the output pipe. So we can for example now send messages back to the client from the thread that runs the async symbol server stuff etc.

Also fixed a number of other bugs that came up.

Once this is merged, I'll open a PR that a) sends crash reports from the symbol server and b) does the progress UI reporting stuff with the new LSP support for that.