### PR TITLE
Detect whether client supports progress stuff

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -52,6 +52,8 @@ mutable struct LanguageServerInstance
 
     current_symserver_progress_token::Union{Nothing,String}
 
+    clientcapability_window_workdoneprogress::Bool
+
     function LanguageServerInstance(pipe_in, pipe_out, debug_mode::Bool = false, env_path = "", depot_path = "", err_handler=nothing)
         new(
             JSONRPCEndpoints.JSONRPCEndpoint(pipe_in, pipe_out, err_handler),
@@ -72,7 +74,8 @@ mutable struct LanguageServerInstance
             err_handler,
             :created,
             0,
-            nothing
+            nothing,
+            false
         )
     end
 end
@@ -84,16 +87,20 @@ function Base.display(server::LanguageServerInstance)
 end
 
 function create_symserver_progress_ui(server)
-    server.current_symserver_progress_token = string(uuid4())
-    response = JSONRPCEndpoints.send_request(server.jr_endpoint, "window/workDoneProgress/create", Dict("token" => server.current_symserver_progress_token))
+    if server.clientcapability_window_workdoneprogress
+        server.current_symserver_progress_token = string(uuid4())
+        response = JSONRPCEndpoints.send_request(server.jr_endpoint, "window/workDoneProgress/create", Dict("token" => server.current_symserver_progress_token))
 
-    JSONRPCEndpoints.send_notification(server.jr_endpoint, "\$/progress", Dict("token" => server.current_symserver_progress_token, "value" => Dict("kind"=>"begin", "title"=>"Julia Language Server", "message"=>"Indexing packages...")))
+        JSONRPCEndpoints.send_notification(server.jr_endpoint, "\$/progress", Dict("token" => server.current_symserver_progress_token, "value" => Dict("kind"=>"begin", "title"=>"Julia Language Server", "message"=>"Indexing packages...")))
+    end
 end
 
 function destroy_symserver_progress_ui(server)
-    progress_token = server.current_symserver_progress_token
-    server.current_symserver_progress_token = nothing
-    JSONRPCEndpoints.send_notification(server.jr_endpoint, "\$/progress", Dict("token" => progress_token, "value" => Dict("kind"=>"end")))    
+    if server.clientcapability_window_workdoneprogress
+        progress_token = server.current_symserver_progress_token
+        server.current_symserver_progress_token = nothing
+        JSONRPCEndpoints.send_notification(server.jr_endpoint, "\$/progress", Dict("token" => progress_token, "value" => Dict("kind"=>"end")))
+    end
 end
 
 function trigger_symbolstore_reload(server::LanguageServerInstance)

--- a/src/protocol/initialize.jl
+++ b/src/protocol/initialize.jl
@@ -161,6 +161,7 @@ end
 @dict_readable struct ClientCapabilities
     workspace::Union{WorkspaceClientCapabilities,Missing}
     textDocument::Union{TextDocumentClientCapabilities,Missing}
+    window::Union{Any,Missing}
     experimental::Union{Any,Missing}
 end
 

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -108,9 +108,6 @@ function process(r::JSONRPC.Request{Val{Symbol("initialize")},InitializeParams},
         end
     end
     
-    @info r.params.capabilities.window["workDoneProgress"]
-    @info typeof(r.params.capabilities.window["workDoneProgress"])
-
     if !ismissing(r.params.capabilities.window) && get(r.params.capabilities.window, "workDoneProgress", false)
         server.clientcapability_window_workdoneprogress = true
     else

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -107,6 +107,15 @@ function process(r::JSONRPC.Request{Val{Symbol("initialize")},InitializeParams},
             push!(server.workspaceFolders, uri2filepath(wksp.uri))
         end
     end
+    
+    @info r.params.capabilities.window["workDoneProgress"]
+    @info typeof(r.params.capabilities.window["workDoneProgress"])
+
+    if !ismissing(r.params.capabilities.window) && get(r.params.capabilities.window, "workDoneProgress", false)
+        server.clientcapability_window_workdoneprogress = true
+    else
+        server.clientcapability_window_workdoneprogress = false
+    end
 
     return InitializeResult(serverCapabilities)
 end


### PR DESCRIPTION
Fixes #494.

I read the spec again, and I think we do need to check to be spec conform. In particular, we are also sending a `window/workDoneProgress/create` request, and we should only do that if the client supports it.