### PR TITLE
Add extensive error output for get_offset

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -65,7 +65,11 @@ function get_offset(doc::Document, line::Integer, character::Integer)
     io = IOBuffer(get_text(doc))
     seek(io, line_offsets[line + 1])
     while character > 0
-        c = read(io, Char)
+        try
+            c = read(io, Char)
+        catch err
+            error("get_offset crashed. More diagnostics:\nline=$line\ncharacter=$character\nposition(io)=$(position(io))\nline_offsets='$line_offsets'\ntext='$(get_text(doc))'\n\noriginal_error=$(sprint(Base.display_error, err, catch_backtrace()))")
+        end
         character -= 1
         if UInt32(c) >= 0x010000
             character -= 1

--- a/src/document.jl
+++ b/src/document.jl
@@ -63,26 +63,26 @@ function get_offset(doc::Document, line::Integer, character::Integer)
     c = ' '
     line_offsets = get_line_offsets(doc)
     io = IOBuffer(get_text(doc))
-    seek(io, line_offsets[line + 1])
-    while character > 0
-        try
+    try
+        seek(io, line_offsets[line + 1])
+        while character > 0        
             c = read(io, Char)
-        catch err
-            error("get_offset crashed. More diagnostics:\nline=$line\ncharacter=$character\nposition(io)=$(position(io))\nline_offsets='$line_offsets'\ntext='$(get_text(doc))'\n\noriginal_error=$(sprint(Base.display_error, err, catch_backtrace()))")
-        end
-        character -= 1
-        if UInt32(c) >= 0x010000
             character -= 1
+            if UInt32(c) >= 0x010000
+                character -= 1
+            end
         end
-    end
-    if UInt32(c) < 0x0080
-        return position(io)
-    elseif UInt32(c) < 0x0800
-        return position(io) - 1
-    elseif UInt32(c) < 0x010000
-        return position(io) - 2
-    else
-        return position(io) - 3
+        if UInt32(c) < 0x0080
+            return position(io)
+        elseif UInt32(c) < 0x0800
+            return position(io) - 1
+        elseif UInt32(c) < 0x010000
+            return position(io) - 2
+        else
+            return position(io) - 3
+        end
+    catch err
+        error("get_offset crashed. More diagnostics:\nline=$line\ncharacter=$character\nposition(io)=$(position(io))\nline_offsets='$line_offsets'\ntext='$(get_text(doc))'\n\noriginal_error=$(sprint(Base.display_error, err, catch_backtrace()))")
     end
 end
 get_offset(doc, p::Position) = get_offset(doc, p.line, p.character)

--- a/test/test_document.jl
+++ b/test/test_document.jl
@@ -64,7 +64,7 @@ d6 = Document("untitled", s6, false)
     LS.applytextdocumentchanges(doc, c3)
     @test LS.get_text(doc) == "println(\"Hello World\")"
     # doc currently has only one line, applying change to 2nd line should throw
-    @test_throws BoundsError LS.applytextdocumentchanges(doc, c2)
+    @test_throws ErrorException LS.applytextdocumentchanges(doc, c2)
 end
 
 @testset "UTF16 handling" begin


### PR DESCRIPTION
Might help diagnose https://github.com/julia-vscode/LanguageServer.jl/issues/501.

I tried it once with a fake error, it seems to work. Not the nicest output, but hopefully we'll get what we need. Do you think this is sufficient?