### PR TITLE
wait for symserv before sending lint errors

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -316,7 +316,7 @@ function mark_errors(doc, out = Diagnostic[])
 end
 
 function publish_diagnostics(doc::Document, server)
-    if server.runlinter
+    if server.runlinter && server.symbol_store_ready
         publishDiagnosticsParams = PublishDiagnosticsParams(doc._uri, doc.diagnostics)
     else
         publishDiagnosticsParams = PublishDiagnosticsParams(doc._uri, Diagnostic[])


### PR DESCRIPTION
This stops us sending lint message until we've loaded symbols. It's not clear to me whether the additional field is necessary or we could use one of the existing symserv related fields