### PR TITLE
Fix string indexing error

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -381,7 +381,7 @@ function parse_jmd(ps, str)
             currentbyte = top.fullspan + 1
         end
     end
-    prec_str_size = currentbyte:sizeof(str)
+    prec_str_size = currentbyte:lastindex(str)
     push!(top.args, CSTParser.mLITERAL(sizeof(str[prec_str_size]), sizeof(str[prec_str_size]), "", CSTParser.Tokens.STRING))
 
     return top, ps


### PR DESCRIPTION
Fixes #522.

In general one should not index into a string with the return value of `sizeof`, that will not work with unicode charachters. I did a quick search of LanguageServer.jl for `sizeof` and it is used 39 times... We should probably take a look at every single instance and decide whether `lastindex` is more appropriate? And we should probably audit the other packages as well?