### PR TITLE
Add access functions for server._documents and remove StaticLint ability to modify docs

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -88,11 +88,11 @@ function Base.display(server::LanguageServerInstance)
     end
 end
 
-function hasdocument(server::LanguageServerInstance, uri:URI2)
+function hasdocument(server::LanguageServerInstance, uri::URI2)
     return haskey(server._documents, uri)
 end
 
-function getdocument(server::LanguageServerInstance, uri:URI2)
+function getdocument(server::LanguageServerInstance, uri::URI2)
     return server._documents[uri]
 end
 

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -230,7 +230,7 @@ function Base.run(server::LanguageServerInstance)
                 root = getroot(doc)
                 if !(root in roots)
                     push!(roots, root)
-                    scopepass(root, doc)
+                    StaticLint.scopepass(root, doc)
                 end
 
                 StaticLint.check_all(getcst(doc), server.lint_options, server)

--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -1,10 +1,7 @@
 JSONRPC.parse_params(::Type{Val{Symbol("textDocument/codeAction")}}, params) = CodeActionParams(params)
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/codeAction")},CodeActionParams}, server)
-    if !haskey(server.documents, URI2(r.params.textDocument.uri))
-        error("Received 'textDocument/action for non-existing document.")
-    end
     commands = Command[]
-    doc = server.documents[URI2(r.params.textDocument.uri)] 
+    doc = getdocument(serverURI2(r.params.textDocument.uri))
     offset = get_offset(doc, r.params.range.start)
     offset1 = get_offset(doc, r.params.range.stop)
     x = get_expr(getcst(doc), offset)
@@ -36,7 +33,7 @@ JSONRPC.parse_params(::Type{Val{Symbol("workspace/executeCommand")}}, params) = 
 function process(r::JSONRPC.Request{Val{Symbol("workspace/executeCommand")},ExecuteCommandParams}, server) 
     uri = r.params.arguments[1]
     offset = r.params.arguments[2]
-    doc = server.documents[URI2(uri)] 
+    doc = getdocument(server, URI2(uri))
     x = get_expr(getcst(doc), offset)
     if r.params.command == "ExplicitPackageVarImport"
         explicitly_import_used_variables(x, r.id + 1, server)

--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -1,7 +1,7 @@
 JSONRPC.parse_params(::Type{Val{Symbol("textDocument/codeAction")}}, params) = CodeActionParams(params)
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/codeAction")},CodeActionParams}, server)
     commands = Command[]
-    doc = getdocument(serverURI2(r.params.textDocument.uri))
+    doc = getdocument(server, URI2(r.params.textDocument.uri))
     offset = get_offset(doc, r.params.range.start)
     offset1 = get_offset(doc, r.params.range.stop)
     x = get_expr(getcst(doc), offset)

--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -9,12 +9,8 @@ end
 
 JSONRPC.parse_params(::Type{Val{Symbol("textDocument/completion")}}, params) = CompletionParams(params)
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/completion")},CompletionParams}, server)
-    if !haskey(server.documents, URI2(r.params.textDocument.uri))
-        error("Received 'textDocument/completion for non-existing document.")
-    end
-    
     CIs = CompletionItem[]
-    doc = server.documents[URI2(r.params.textDocument.uri)]
+    doc = getdocument(server, URI2(r.params.textDocument.uri))
     offset = get_offset(doc, r.params.position)
     rng = Range(doc, offset:offset)
     ppt, pt, t, is_at_end  = get_partial_completion(doc, offset)

--- a/src/requests/hover.jl
+++ b/src/requests/hover.jl
@@ -1,9 +1,6 @@
 JSONRPC.parse_params(::Type{Val{Symbol("textDocument/hover")}}, params) = TextDocumentPositionParams(params)
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/hover")},TextDocumentPositionParams}, server)
-    if !haskey(server.documents, URI2(r.params.textDocument.uri))
-        error("Received 'textDocument/hover for non-existing document.")
-    end
-    doc = server.documents[URI2(r.params.textDocument.uri)]
+    doc = getdocument(server, URI2(r.params.textDocument.uri))
     x = get_expr1(getcst(doc), get_offset(doc, r.params.position))
     documentation = get_hover(x, "", server)
     documentation = get_fcall_position(x, documentation)

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -72,6 +72,7 @@ function load_folder(wf::WorkspaceFolder, server)
 end
 
 function load_folder(path::String, server)
+    docs_to_parse = []
     if load_rootpath(path)
         for (root, dirs, files) in walkdir(path, onerror = x->x)
             for file in files
@@ -85,10 +86,14 @@ function load_folder(path::String, server)
                         content = read(filepath, String)
                         doc = Document(uri, content, true, server)
                         setdocument!(server, URI2(uri), doc)
-                        parse_all(doc, server)
+                        push!(docs_to_parse, doc)                        
                     end
                 end
             end
+        end
+
+        for doc in docs_to_parse
+            parse_all(doc, server)
         end
     end
 end

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -79,12 +79,12 @@ function load_folder(path::String, server)
                 if isvalidjlfile(filepath)
                     !isfile(filepath) && continue
                     uri = filepath2uri(filepath)
-                    if URI2(uri) in keys(server.documents)
+                    if hasdocument(server, URI2(uri))
                         continue
                     else
                         content = read(filepath, String)
-                        server.documents[URI2(uri)] = Document(uri, content, true, server)
-                        doc = server.documents[URI2(uri)]
+                        doc = Document(uri, content, true, server)
+                        setdocument!(server, URI2(uri), doc)
                         parse_all(doc, server)
                     end
                 end

--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -9,7 +9,7 @@ function process(r::JSONRPC.Request{Val{Symbol("julia/lint-package")},Nothing}, 
 
 JSONRPC.parse_params(::Type{Val{Symbol("julia/toggle-lint")}}, params) = TextDocumentIdentifier(params["textDocument"])
 function process(r::JSONRPC.Request{Val{Symbol("julia/toggle-lint")},TextDocumentIdentifier}, server)
-    doc = server.documents[URI2(r.uri)]
+    doc = getdocument(server, URI2(r.uri))
     doc._runlinter = !doc._runlinter
 end
 
@@ -27,11 +27,8 @@ end
 
 JSONRPC.parse_params(::Type{Val{Symbol("julia/getCurrentBlockRange")}}, params) = TextDocumentPositionParams(params)
 function process(r::JSONRPC.Request{Val{Symbol("julia/getCurrentBlockRange")},TextDocumentPositionParams}, server)
-    if !haskey(server.documents, URI2(r.params.textDocument.uri))
-        error("Received 'julia/getCurrentBlockRange for non-existing document.")
-    end
     tdpp = r.params
-    doc = server.documents[URI2(tdpp.textDocument.uri)]
+    doc = getdocument(server, URI2(tdpp.textDocument.uri))
     offset = get_offset(doc, tdpp.position)
     x = getcst(doc)
     loc = 0

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -2,24 +2,49 @@ JSONRPC.parse_params(::Type{Val{Symbol("workspace/didChangeWatchedFiles")}}, par
 function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles")},DidChangeWatchedFilesParams}, server)
     for change in r.params.changes
         uri = change.uri
-        # TODO DA This seems like a bug, in the case of a create we should
-        # read the file from disc and add it to documents.
-        !hasdocument(server, URI2(uri)) && continue
-        doc = getdocument(server, URI2(uri))
-        if change.type == FileChangeTypes["Created"] || (change.type == FileChangeTypes["Changed"] && !get_open_in_editor(doc))
+
+        if change.type == FileChangeTypes["Created"]
+            if hasdocument(server, URI2(uri))
+                doc = getdocument(server, URI2(uri))
+
+                # Currently managed by the client, we don't do anything
+                if get_open_in_editor(doc)
+                    continue
+                else
+                    error("Received a create notification for a file we already manage.")
+                end
+            end
+
             filepath = uri2filepath(uri)
             content = String(read(filepath))
-            content == get_text(doc) && return
 
             doc = Document(uri, content, true, server)
             setdocument!(server, URI2(uri), doc)
             parse_all(doc, server)
+        elseif change.type == FileChangeTypes["Changed"]
+            doc = getdocument(server, URI2(uri))
 
-        elseif change.type == FileChangeTypes["Deleted"] && !get_open_in_editor(doc)
-            deletedocument!(server, URI2(uri))
+            # We only handle if currently not managed by client
+            if !get_open_in_editor(doc)
+                filepath = uri2filepath(uri)
+                content = String(read(filepath))
+    
+                doc = Document(uri, content, true, server)
+                setdocument!(server, URI2(uri), doc)
+                parse_all(doc, server)                            
+            end
+        elseif change.type == FileChangeTypes["Deleted"]
+            doc = getdocument(server, URI2(uri))
 
-            publishDiagnosticsParams = PublishDiagnosticsParams(uri, missing, Diagnostic[])
-            JSONRPCEndpoints.send_notification(server.jr_endpoint, "textDocument/publishDiagnostics", publishDiagnosticsParams)
+            # We only handle if currently not managed by client
+            if !get_open_in_editor(doc)
+                deletedocument!(server, URI2(uri))
+
+                publishDiagnosticsParams = PublishDiagnosticsParams(uri, missing, Diagnostic[])
+                JSONRPCEndpoints.send_notification(server.jr_endpoint, "textDocument/publishDiagnostics", publishDiagnosticsParams)
+            end                
+        else
+            error("Unknown change type.")
         end
     end
 end

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -2,17 +2,21 @@ JSONRPC.parse_params(::Type{Val{Symbol("workspace/didChangeWatchedFiles")}}, par
 function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles")},DidChangeWatchedFilesParams}, server)
     for change in r.params.changes
         uri = change.uri
-        !haskey(server.documents, URI2(uri)) && continue
-        if change.type == FileChangeTypes["Created"] || (change.type == FileChangeTypes["Changed"] && !get_open_in_editor(server.documents[URI2(uri)]))
-            doc = server.documents[URI2(uri)]
+        # TODO DA This seems like a bug, in the case of a create we should
+        # read the file from disc and add it to documents.
+        !hasdocument(server, URI2(uri)) && continue
+        doc = getdocument(server, URI2(uri))
+        if change.type == FileChangeTypes["Created"] || (change.type == FileChangeTypes["Changed"] && !get_open_in_editor(doc))
             filepath = uri2filepath(uri)
             content = String(read(filepath))
             content == get_text(doc) && return
-            server.documents[URI2(uri)] = Document(uri, content, true, server)
-            parse_all(server.documents[URI2(uri)], server)
 
-        elseif change.type == FileChangeTypes["Deleted"] && !get_open_in_editor(server.documents[URI2(uri)])
-            delete!(server.documents, URI2(uri))
+            doc = Document(uri, content, true, server)
+            setdocument!(server, URI2(uri), doc)
+            parse_all(doc, server)
+
+        elseif change.type == FileChangeTypes["Deleted"] && !get_open_in_editor(doc)
+            deletedocument!(server, URI2(uri))
 
             publishDiagnosticsParams = PublishDiagnosticsParams(uri, missing, Diagnostic[])
             JSONRPCEndpoints.send_notification(server.jr_endpoint, "textDocument/publishDiagnostics", publishDiagnosticsParams)
@@ -66,7 +70,7 @@ function request_julia_config(server)
         if new_run_lint_value != server.runlinter || any(getfield(new_lint_opts, n) != getfield(server.lint_options, n) for n in fieldnames(StaticLint.LintOptions))
             server.lint_options = new_lint_opts
             server.runlinter = new_run_lint_value
-            for doc in values(server.documents)
+            for doc in getdocuments_value(server)
                 StaticLint.check_all(getcst(doc), server.lint_options, server)
                 empty!(doc.diagnostics)
                 mark_errors(doc, doc.diagnostics)
@@ -92,7 +96,7 @@ end
 JSONRPC.parse_params(::Type{Val{Symbol("workspace/symbol")}}, params) = WorkspaceSymbolParams(params) 
 function process(r::JSONRPC.Request{Val{Symbol("workspace/symbol")},WorkspaceSymbolParams}, server) 
     syms = SymbolInformation[]
-    for (uri,doc) in server.documents
+    for doc in getdocuments_value(server)
         bs = collect_toplevel_bindings_w_loc(getcst(doc), query = r.params.query)
         for x in bs
             p, b = x[1], x[2]

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -1,6 +1,6 @@
 import StaticLint: hasfile, canloadfile, loadfile, setfile, getfile, getsymbolserver
 import StaticLint: getpath, setpath, getroot, setroot, getcst, setcst, scopepass, getserver, setserver
-hasfile(server::LanguageServerInstance, path::String) = haskey(server.documents, URI2(filepath2uri(path)))
+hasfile(server::LanguageServerInstance, path::String) = hasdocument(server, URI2(filepath2uri(path)))
 canloadfile(server::LanguageServerInstance, path::String) = isfile(path)
 function loadfile(server::LanguageServerInstance, path::String)
     source = read(path, String)
@@ -8,8 +8,8 @@ function loadfile(server::LanguageServerInstance, path::String)
     doc = Document(uri, source, true, server)
     StaticLint.setfile(server, path, doc)
 end
-setfile(server::LanguageServerInstance, path::String, x::Document) = server.documents[URI2(filepath2uri(path))] = x
-getfile(server::LanguageServerInstance, path::String) = server.documents[URI2(filepath2uri(path))]
+setfile(server::LanguageServerInstance, path::String, x::Document) = setdocument!(server, URI2(filepath2uri(path)), x)
+getfile(server::LanguageServerInstance, path::String) = getdocument(server, URI2(filepath2uri(path)))
 getsymbolserver(server::LanguageServerInstance) = server.symbol_store
 
 getpath(d::Document) = d.path

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -1,37 +1,20 @@
-import StaticLint: hasfile, canloadfile, loadfile, setfile, getfile, getsymbolserver
-import StaticLint: getpath, setpath, getroot, setroot, getcst, setcst, scopepass, getserver, setserver
-hasfile(server::LanguageServerInstance, path::String) = hasdocument(server, URI2(filepath2uri(path)))
-canloadfile(server::LanguageServerInstance, path::String) = isfile(path)
-function loadfile(server::LanguageServerInstance, path::String)
-    source = read(path, String)
-    uri = filepath2uri(path)
-    doc = Document(uri, source, true, server)
-    StaticLint.setfile(server, path, doc)
-end
-setfile(server::LanguageServerInstance, path::String, x::Document) = setdocument!(server, URI2(filepath2uri(path)), x)
-getfile(server::LanguageServerInstance, path::String) = getdocument(server, URI2(filepath2uri(path)))
-getsymbolserver(server::LanguageServerInstance) = server.symbol_store
+import StaticLint
 
-getpath(d::Document) = d.path
-function setpath(d::Document, path::String)
-    d.path = path
-    return d
-end
+StaticLint.hasfile(server::LanguageServerInstance, path::String) = hasdocument(server, URI2(filepath2uri(path)))
 
-getroot(d::Document) = d.root
-function setroot(d::Document, root::Document)
+StaticLint.getfile(server::LanguageServerInstance, path::String) = getdocument(server, URI2(filepath2uri(path)))
+
+StaticLint.getsymbolserver(server::LanguageServerInstance) = server.symbol_store
+
+StaticLint.getpath(d::Document) = d.path
+
+StaticLint.getroot(d::Document) = d.root
+
+function StaticLint.setroot(d::Document, root::Document)
     d.root = root
     return d
 end
 
-getcst(d::Document) = d.cst
-function setcst(d::Document, cst::EXPR)
-    d.cst = cst
-    return d
-end
+StaticLint.getcst(d::Document) = d.cst
 
-getserver(file::Document) = file.server
-function setserver(file::Document, server::LanguageServerInstance)
-    file.server = server
-    return file
-end
+StaticLint.getserver(file::Document) = file.server

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -72,7 +72,7 @@ end
 is_ignored(uri::URI2, server) = is_ignored(uri._uri, server)
 
 function remove_workspace_files(root, server)
-    for (uri, doc) in server.documents
+    for (uri, doc) in getdocuments_pair(server)
         fpath = uri2filepath(uri._uri)
         doc._open_in_editor && continue
         if startswith(fpath, fpath)
@@ -80,7 +80,7 @@ function remove_workspace_files(root, server)
                 if startswith(fpath, folder)
                     continue
                 end
-                delete!(server.documents, uri)
+                deletedocument!(server, uri)
             end
         end
     end
@@ -89,7 +89,7 @@ end
 
 function Base.getindex(server::LanguageServerInstance, r::Regex)
     out = []
-    for (uri,doc) in server.documents
+    for (uri,doc) in getdocuments_pair(server)
         occursin(r, uri._uri) && push!(out, doc)
     end
     return out

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -13,7 +13,7 @@ end
 
 function load_file(text, server)
     process(Request{Val{Symbol("textDocument/didOpen")},LanguageServer.DidOpenTextDocumentParams}(0, LanguageServer.DidOpenTextDocumentParams(LanguageServer.TextDocumentItem("none", "julia", 0, text))), server)
-    doc = server.documents[LanguageServer.URI2("none")]
+    doc = LanguageServer.getdocument(server, LanguageServer.URI2("none"))
 end
 
 function hover(text, line, col, server)

--- a/test/test_bruteforce.jl
+++ b/test/test_bruteforce.jl
@@ -24,7 +24,7 @@ r = parse(Request, LanguageServer.JSON.parse("""{"jsonrpc":"2.0","id":59,"method
 process(r, server);
 
 # Document Symbols
-for doc in values(server.documents)
+for doc in LanguageServer.getdocuments_value(server)
     uri = doc._uri
     r = parse(Request, LanguageServer.JSON.parse("""{"jsonrpc":"2.0","id":1,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"$(uri)"}}}"""))
     process(r, server)
@@ -32,7 +32,7 @@ end
 
 # Hovers
 
-for doc in values(server.documents)
+for doc in LanguageServer.getdocuments_value(server)
     uri = doc._uri
     print("Hovers: $uri ")
     for loc in 1:sizeof(LanguageServer.get_text(doc))-1
@@ -43,7 +43,7 @@ for doc in values(server.documents)
 end
 
 # Completions
-for doc in values(server.documents)
+for doc in LanguageServer.getdocuments_value(server)
     uri = doc._uri
     print("Completions: $uri ")
     for loc in 1:sizeof(LanguageServer.get_text(doc))-1
@@ -55,7 +55,7 @@ for doc in values(server.documents)
 end
 
 # Definitions
-for doc in values(server.documents)
+for doc in LanguageServer.getdocuments_value(server)
     uri = doc._uri
     print("Definitions: $uri ")
     for loc in 1:sizeof(LanguageServer.get_text(doc))-1
@@ -67,7 +67,7 @@ for doc in values(server.documents)
 end
 
 # Signatures
-for doc in values(server.documents)
+for doc in LanguageServer.getdocuments_value(server)
     uri = doc._uri
     print("Signatures: $uri ")
     for loc in 1:sizeof(LanguageServer.get_text(doc))-1
@@ -79,7 +79,7 @@ for doc in values(server.documents)
 end
 
 # References
-for doc in values(server.documents)
+for doc in LanguageServer.getdocuments_value(server)
     uri = doc._uri
     print("References: $uri ")
     for loc in 1:sizeof(doc._content)-1

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -18,7 +18,7 @@ testmodule
 """
 LanguageServer.process(LanguageServer.JSONRPC.Request{Val{Symbol("textDocument/didOpen")},LanguageServer.DidOpenTextDocumentParams}(0, LanguageServer.DidOpenTextDocumentParams(LanguageServer.TextDocumentItem("testdoc", "julia", 0, testtext))), server)
 
-doc = server.documents[LanguageServer.URI2("testdoc")]
+doc = LanguageServer.getdocument(server, LanguageServer.URI2("testdoc"))
 LanguageServer.parse_all(doc, server)
 
 

--- a/test/text_edit.jl
+++ b/test/text_edit.jl
@@ -11,7 +11,7 @@ mktempdir() do dir
 
     function test_edit(server, text, s1, s2, insert)
         LanguageServer.process(LanguageServer.JSONRPC.Request{Val{Symbol("textDocument/didOpen")},LanguageServer.DidOpenTextDocumentParams}(0,LanguageServer.DidOpenTextDocumentParams(LanguageServer.TextDocumentItem("none", "julia", 0, text))), server)
-        doc = server.documents[LanguageServer.URI2("none")]
+        doc = LanguageServer.getdocument(server, LanguageServer.URI2("none"))
         LanguageServer.parse_all(doc, server)
         r = LanguageServer.JSONRPC.Request{Val{Symbol("textDocument/didChange")},LanguageServer.DidChangeTextDocumentParams}(0, LanguageServer.DidChangeTextDocumentParams(LanguageServer.VersionedTextDocumentIdentifier(doc._uri, 5),
         [LanguageServer.TextDocumentContentChangeEvent(LanguageServer.Range(LanguageServer.Position(s1...), LanguageServer.Position(s2...)), 0, insert)]))


### PR DESCRIPTION
I think this is the first step to fix our document corruption issue. ~~I'll open another PR that will build on this that tries to actually fix some things, i.e. this PR here should not change behaviour at all.~~

I did remove a couple of `hasdocument` checks in cases where immediately after that block we call `getdocument`. That is going to error already, so no need for another conditional that then just throws an error.

I also replaced a couple of `x in keys(server.documents)` with `hasdocument(...)`.

The main benefit of this (IMO) is that it makes it much easier to find the locations where state is changed.

This PR now also removes the ability of StaticLint.jl to load docs, or change anything about which files are loaded, what their content etc. is. I think we should think of StaticLint.jl as operating on a virtual file system that is provided by LanguageServer, without the complicated ability for StaticLint to control which files are loaded etc.

Needs https://github.com/julia-vscode/StaticLint.jl/pull/99.

I'm not entirely sure whether the combination of those two PRs works properly at this stage :) But I think in terms of structure that is where we should go.