### PR TITLE
Make sure the workspace flag is always set properly

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -52,6 +52,11 @@ function is_workspace_file(doc::Document)
     return doc._workspace_file
 end
 
+function set_is_workspace_file(doc::Document, value::Bool)
+    doc._workspace_file = value
+end
+
+
 """
     get_offset(doc, line, char)
 

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -80,6 +80,7 @@ function load_folder(path::String, server)
                     !isfile(filepath) && continue
                     uri = filepath2uri(filepath)
                     if hasdocument(server, URI2(uri))
+                        set_is_workspace_file(getdocument(server, URI2(uri)), true)
                         continue
                     else
                         content = read(filepath, String)


### PR DESCRIPTION
Right now, if a file is open in the editor, and then someone adds a folder to the workspace, that file wouldn't be marked properly as belonging to the workspace.