### PR TITLE
Use accessor and remove redundant check in remove_workspace_files

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -71,17 +71,18 @@ end
 
 is_ignored(uri::URI2, server) = is_ignored(uri._uri, server)
 
+# TODO I believe this will also remove files from documents that were added
+# not because they are part of the workspace, but by either StaticLint or
+# the include follow logic.
 function remove_workspace_files(root, server)
     for (uri, doc) in getdocuments_pair(server)
         fpath = uri2filepath(uri._uri)
-        doc._open_in_editor && continue
-        if startswith(fpath, fpath)
-            for folder in server.workspaceFolders
-                if startswith(fpath, folder)
-                    continue
-                end
-                deletedocument!(server, uri)
+        get_open_in_editor(doc) && continue
+        for folder in server.workspaceFolders
+            if startswith(fpath, folder)
+                continue
             end
+            deletedocument!(server, uri)
         end
     end
 end


### PR DESCRIPTION
I think that `if` statement will always be `true`, right? So I removed it :)