### PR TITLE
Throw an error if StaticLint does something it shouldn't do

### DIFF
--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -8,7 +8,14 @@ function loadfile(server::LanguageServerInstance, path::String)
     doc = Document(uri, source, true, server)
     StaticLint.setfile(server, path, doc)
 end
-setfile(server::LanguageServerInstance, path::String, x::Document) = setdocument!(server, URI2(filepath2uri(path)), x)
+function setfile(server::LanguageServerInstance, path::String, x::Document)
+    uri = URI2(filepath2uri(path))
+    if hasdocument(server, uri)
+        error("StaticLint should not try to set documents that are already tracked.")
+    end
+
+    setdocument!(server, uri, x)
+end
 getfile(server::LanguageServerInstance, path::String) = getdocument(server, URI2(filepath2uri(path)))
 getsymbolserver(server::LanguageServerInstance) = server.symbol_store
 


### PR DESCRIPTION
As far as I can tell, StaticLint should never try to set a doc that already exists, this just adds an error if it does so that we would see that in crash reporting. I think if I understand the code correctly, that branch should actually never be hit.