### PR TITLE
Fix the implementation of didChangeWatchedFiles

### DIFF
--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -2,28 +2,56 @@ JSONRPC.parse_params(::Type{Val{Symbol("workspace/didChangeWatchedFiles")}}, par
 function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles")},DidChangeWatchedFilesParams}, server)
     for change in r.params.changes
         uri = change.uri
-        # TODO DA This seems like a bug, in the case of a create we should
-        # read the file from disc and add it to documents.
-        !hasdocument(server, URI2(uri)) && continue
-        doc = getdocument(server, URI2(uri))
-        if change.type == FileChangeTypes["Created"] || (change.type == FileChangeTypes["Changed"] && !get_open_in_editor(doc))
+
+        if change.type == FileChangeTypes["Created"]
+            if hasdocument(server, URI2(uri))
+                doc = getdocument(server, URI2(uri))
+
+                # Currently managed by the client, we don't do anything
+                if get_open_in_editor(doc)
+                    continue
+                else
+                    error("Received a create notification for a file we already manage.")
+                end
+            end
+
             filepath = uri2filepath(uri)
             content = String(read(filepath))
-            content == get_text(doc) && return
 
             doc = Document(uri, content, true, server)
             setdocument!(server, URI2(uri), doc)
             parse_all(doc, server)
+        elseif change.type == FileChangeTypes["Changed"]
+            doc = getdocument(server, URI2(uri))
 
-        elseif change.type == FileChangeTypes["Deleted"] && !get_open_in_editor(doc)
-            deletedocument!(server, URI2(uri))
+            # We only handle if currently not managed by client
+            if !get_open_in_editor(doc)
+                filepath = uri2filepath(uri)
+                content = String(read(filepath))
+    
+                doc = Document(uri, content, true, server)
+                setdocument!(server, URI2(uri), doc)
+                parse_all(doc, server)                            
+            end
+        elseif change.type == FileChangeTypes["Deleted"]
+            doc = getdocument(server, URI2(uri))
 
-            publishDiagnosticsParams = PublishDiagnosticsParams(uri, missing, Diagnostic[])
-            JSONRPCEndpoints.send_notification(server.jr_endpoint, "textDocument/publishDiagnostics", publishDiagnosticsParams)
+            # We only handle if currently not managed by client
+            if !get_open_in_editor(doc)
+                deletedocument!(server, URI2(uri))
+
+                publishDiagnosticsParams = PublishDiagnosticsParams(uri, missing, Diagnostic[])
+                JSONRPCEndpoints.send_notification(server.jr_endpoint, "textDocument/publishDiagnostics", publishDiagnosticsParams)
+            else
+                # TODO replace with accessor function once the other PR
+                # that introduces the accessor is merged
+                doc._workspace_file = false
+            end                
+        else
+            error("Unknown change type.")
         end
     end
 end
-
 
 JSONRPC.parse_params(::Type{Val{Symbol("workspace/didChangeConfiguration")}}, params) = params
 function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeConfiguration")},Dict{String,Any}}, server::LanguageServerInstance)


### PR DESCRIPTION
Some problems with the current implementation:
- it did not properly handle create requests (in particular, if the doc was not already in `server.documents`, it did nothing)
- it did not mark deleted files as no longer in the workspace. That meant that if such a file was open in the editor, and then we received a `didClose`, this file would hang around in `server.documents`, even though it shouldn't.