### PR TITLE
Remove buggy URI2 conversion

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -62,7 +62,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didClose")},DidClos
             # ...otherwise we delete all documents that share root with doc.
             for (u,d) in getdocuments_pair(server)
                 if d.root == doc.root
-                    deletedocument!(server, URI2(u))
+                    deletedocument!(server, u)
                 end
             end
         end


### PR DESCRIPTION
I'm going to merge right away so that I can cut a new RC. This came in via crash reporting and I hope the fix is simple enough :) `u` simply is a `URI2` already.

EDIT: And boy, we really need to write tests ;) v0.15.0...