### PR TITLE
Only handle didChangeWatchedFiles for file: schema

### DIFF
--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -3,6 +3,8 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
     for change in r.params.changes
         uri = change.uri
 
+        startswith(uri, "file:") || continue
+
         if change.type == FileChangeTypes["Created"]
             if hasdocument(server, URI2(uri))
                 doc = getdocument(server, URI2(uri))


### PR DESCRIPTION
We have a crash report with an event here that has a URI that starts with `git:`. I don't really understand why we would get that in the first place, but clearly we can't handle anything other than pure `file:` schema events here, so for now I'm just filtering on that.

This fix is hopefully good enough for the next release, I'm also following up upstream how we are supposed to handle that kind of thing...