### PR TITLE
Kill ss process on exit request

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -145,6 +145,7 @@ function process(r::JSONRPC.Request{Val{Symbol("shutdown")}}, server)
 end
 
 JSONRPC.parse_params(::Type{Val{Symbol("exit")}}, params) = params
-function process(r::JSONRPC.Request{Val{Symbol("exit")}}, server) 
+function process(r::JSONRPC.Request{Val{Symbol("exit")}}, server::LanguageServerInstance) 
+    server.symbol_server.process isa Base.Process && kill(server.symbol_server.process)
     exit()
 end


### PR DESCRIPTION
I have definitely experienced an orphan SymServ process (on linux). This could fix this, and seems safe in any case.