### PR TITLE
check for invalid char

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -77,7 +77,7 @@ function get_offset(doc::Document, line::Integer, character::Integer)
                 character -= 1
             end
         end
-        if UInt32(c) < 0x0080
+        if Base.invalid_char(c) || UInt32(c) < 0x0080
             return position(io)
         elseif UInt32(c) < 0x0800
             return position(io) - 1

--- a/src/document.jl
+++ b/src/document.jl
@@ -73,11 +73,11 @@ function get_offset(doc::Document, line::Integer, character::Integer)
         while character > 0        
             c = read(io, Char)
             character -= 1
-            if !Base.invalid_char(c) && UInt32(c) >= 0x010000
+            if !is_invalid_char(c) && UInt32(c) >= 0x010000
                 character -= 1
             end
         end
-        if Base.invalid_char(c) || UInt32(c) < 0x0080
+        if is_invalid_char(c) || UInt32(c) < 0x0080
             return position(io)
         elseif UInt32(c) < 0x0800
             return position(io) - 1
@@ -174,7 +174,7 @@ function get_position_at(doc::Document, offset::Integer)
     while offset > position(io)
         c = read(io, Char)
         character += 1
-        if !Base.invalid_char(c) && UInt32(c) >= 0x010000
+        if !is_invalid_char(c) && UInt32(c) >= 0x010000
             character += 1
         end
     end

--- a/src/document.jl
+++ b/src/document.jl
@@ -73,7 +73,7 @@ function get_offset(doc::Document, line::Integer, character::Integer)
         while character > 0        
             c = read(io, Char)
             character -= 1
-            if UInt32(c) >= 0x010000
+            if !Base.invalid_char(c) && UInt32(c) >= 0x010000
                 character -= 1
             end
         end
@@ -174,7 +174,7 @@ function get_position_at(doc::Document, offset::Integer)
     while offset > position(io)
         c = read(io, Char)
         character += 1
-        if UInt32(c) >= 0x010000
+        if !Base.invalid_char(c) && UInt32(c) >= 0x010000
             character += 1
         end
     end

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -288,7 +288,7 @@ function mark_errors(doc, out = Diagnostic[])
             while line_offsets[line] <= offset < line_offsets[line + 1]
                 while offset > position(io)
                     c = read(io, Char)
-                    if !Base.invalid_char(c) && UInt32(c) >= 0x010000
+                    if !is_invalid_char(c) && UInt32(c) >= 0x010000
                         char += 1
                     end
                     char += 1

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -285,14 +285,14 @@ function mark_errors(doc, out = Diagnostic[])
         while line < nlines
             seek(io, line_offsets[line])
             char = 0
-            while line_offsets[line] <= offset < line_offsets[line + 1]  
+            while line_offsets[line] <= offset < line_offsets[line + 1]
                 while offset > position(io)
                     c = read(io, Char)
-                    if UInt32(c) >= 0x010000
+                    if !Base.invalid_char(c) && UInt32(c) >= 0x010000
                         char += 1
                     end
                     char += 1
-                end                  
+                end
                 if start
                     r[1] = line
                     r[2] = char

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -266,3 +266,11 @@ function sanitize_docstring(doc::String)
     doc = replace(doc,"\n#"=>"\n###")
     return doc
 end
+
+function is_invalid_char(c)
+    u = reinterpret(UInt32, c)
+    l1 = leading_ones(u)
+    t0 = trailing_zeros(u) & 56
+    (l1 == 1) | (8l1 + t0 > 32) |
+    ((((u & 0x00c0c0c0) ⊻ 0x00808080) >> t0 != 0) | Base.is_overlong_enc(u))
+end


### PR DESCRIPTION
An attempt to fix #563. Assumes that invalid Chars are always `<= 0x010000` (I don't know enough about bitshifting etc to understand `Base.invalid_char`). 