### PR TITLE
Validate utf8

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -84,6 +84,7 @@ function load_folder(path::String, server)
                         continue
                     else
                         content = read(filepath, String)
+                        isvalid(content) || continue
                         doc = Document(uri, content, true, server)
                         setdocument!(server, URI2(uri), doc)
                         parse_all(doc, server)

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -414,7 +414,9 @@ function is_parentof(parent_path, child_path, server)
     # load parent file
     puri = filepath2uri(parent_path)
     if !hasdocument(server, URI2(puri))
-        pdoc = Document(puri, read(parent_path, String), false, server)
+        new_content = read(parent_path, String)
+        isvalid(new_content) || return false
+        pdoc = Document(puri, new_content, false, server)
         setdocument!(server, URI2(puri), pdoc)
         CSTParser.parse(get_text(pdoc))
         if typof(pdoc.cst) === CSTParser.FileH

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -4,6 +4,8 @@ hasfile(server::LanguageServerInstance, path::String) = hasdocument(server, URI2
 canloadfile(server::LanguageServerInstance, path::String) = isfile(path)
 function loadfile(server::LanguageServerInstance, path::String)
     source = read(path, String)
+    # Don't load invalid files
+    isvalid(source) || return
     uri = filepath2uri(path)
     doc = Document(uri, source, true, server)
     StaticLint.setfile(server, path, doc)


### PR DESCRIPTION
This is an alternative "fix" for #566, i.e. it is an alternative for https://github.com/julia-vscode/LanguageServer.jl/pull/566.

This PR here adds really two things:
- Whenever we load files from disc, it checks whether they are valid UTF-8 strings, if not, they are not loaded. We should probably have that no matter what, given that users can always have some invalid file laying around.
- It errors if we receive an invalid UTF-8 string from the language server client. It also checks for valid UTF-8 after we have applied incremental sync changes, so it would crash if there is still some problem there.

This PR might just fix the problem (if the source is an invalid file we read), or it might help track down a problem we still might have with text sync.