### PR TITLE
Fix symbol server error handling on older Julia versions

### DIFF
--- a/src/LanguageServer.jl
+++ b/src/LanguageServer.jl
@@ -6,6 +6,7 @@ using StaticLint: refof, scopeof, bindingof
 using UUIDs
 export LanguageServerInstance
 
+include("exception_types.jl")
 include("jsonrpcendpoint.jl")
 include("uri2.jl")
 include("protocol/protocol.jl")

--- a/src/exception_types.jl
+++ b/src/exception_types.jl
@@ -1,0 +1,7 @@
+struct LSSymbolServerFailure <: Exception
+    msg::AbstractString
+end
+
+function Base.showerror(io::IO, ex::LSSymbolServerFailure)
+    print(io, ex.msg)
+end

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -153,7 +153,11 @@ function trigger_symbolstore_reload(server::LanguageServerInstance)
         if ssi_ret==:success
             push!(server.symbol_results_channel, payload)
         elseif ssi_ret==:failure
-            error("The symbol server failed with '$(String(take!(payload)))'")
+            if payload===nothing
+                throw(LSSymbolServerFailure(""))
+            else
+                throw(LSSymbolServerFailure(String(take!(payload))))
+            end
         end
         server.symbol_store_ready = true
     catch err


### PR DESCRIPTION
Fixes an error from crash reporting.

I'm also introducing a new exception type here. The crash reporting can distinguish different different exception types, so this way we don't lump all `ErrorExceptions` into the same bucket.