### PR TITLE
Wrap all file IO in exception handler and check for invalid UTF-8 sequences

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -113,14 +113,7 @@ function setdocument!(server::LanguageServerInstance, uri::URI2, doc::Document)
 end
 
 function deletedocument!(server::LanguageServerInstance, uri::URI2)
-    doc = getdocument(uri)
     delete!(server._documents, uri)
-
-    for d in getdocuments_value(server)
-        if d.root===doc
-            d.root = nothing
-        end
-    end
 end
 
 function create_symserver_progress_ui(server)

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -113,7 +113,14 @@ function setdocument!(server::LanguageServerInstance, uri::URI2, doc::Document)
 end
 
 function deletedocument!(server::LanguageServerInstance, uri::URI2)
+    doc = getdocument(uri)
     delete!(server._documents, uri)
+
+    for d in getdocuments_value(server)
+        if d.root===doc
+            d.root = nothing
+        end
+    end
 end
 
 function create_symserver_progress_ui(server)

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -77,13 +77,16 @@ function load_folder(path::String, server)
             for file in files
                 filepath = joinpath(root, file)
                 if isvalidjlfile(filepath)
-                    !isfile(filepath) && continue
                     uri = filepath2uri(filepath)
                     if hasdocument(server, URI2(uri))
                         set_is_workspace_file(getdocument(server, URI2(uri)), true)
                         continue
                     else
-                        content = read(filepath, String)
+                        content = try
+                            read(filepath, String)
+                        catch err
+                            continue
+                        end
                         doc = Document(uri, content, true, server)
                         setdocument!(server, URI2(uri), doc)
                         parse_all(doc, server)

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -83,7 +83,12 @@ function load_folder(path::String, server)
                         continue
                     else
                         content = try
-                            read(filepath, String)
+                            s = read(filepath, String)
+                            # We throw an error in the case of an invalid
+                            # UTF-8 sequence so that the same code path
+                            # is used that handles file IO problems
+                            isvalid(s) || error()
+                            s
                         catch err
                             continue
                         end

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -15,7 +15,12 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                 else
                     filepath = uri2filepath(uri)
                     content = try
-                        read(filepath, String)
+                        s = read(filepath, String)
+                        # We throw an error in the case of an invalid
+                        # UTF-8 sequence so that the same code path
+                        # is used that handles file IO problems
+                        isvalid(s) || error()
+                        s
                     catch err
                         deletedocument!(server, URI2(uri))
                         continue
@@ -28,7 +33,12 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
             else
                 filepath = uri2filepath(uri)
                 content = try
-                    read(filepath, String)
+                    s = read(filepath, String)
+                    # We throw an error in the case of an invalid
+                    # UTF-8 sequence so that the same code path
+                    # is used that handles file IO problems
+                    isvalid(s) || error()
+                    s
                 catch err
                     continue
                 end

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -14,7 +14,11 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                     continue
                 else
                     filepath = uri2filepath(uri)
-                    content = String(read(filepath))
+                    content = try
+                        read(filepath, String)
+                    catch err
+                        continue
+                    end
         
                     set_text!(doc, content)
                     set_is_workspace_file(doc, true)
@@ -22,7 +26,11 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                 end
             else
                 filepath = uri2filepath(uri)
-                content = String(read(filepath))
+                content = try
+                    read(filepath, String)
+                catch err
+                    continue
+                end
     
                 doc = Document(uri, content, true, server)
                 setdocument!(server, URI2(uri), doc)
@@ -34,7 +42,11 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
             # We only handle if currently not managed by client
             if !get_open_in_editor(doc)
                 filepath = uri2filepath(uri)
-                content = String(read(filepath))
+                content = try
+                    read(filepath, String)
+                catch err
+                    continue
+                end
     
                 set_text!(doc, content)
                 set_is_workspace_file(doc, true)

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -5,7 +5,7 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
 
         startswith(uri, "file:") || continue
 
-        if change.type == FileChangeTypes["Created"]
+        if change.type == FileChangeTypes["Created"] || change.type == FileChangeTypes["Changed"]
             if hasdocument(server, URI2(uri))
                 doc = getdocument(server, URI2(uri))
 
@@ -17,6 +17,7 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                     content = try
                         read(filepath, String)
                     catch err
+                        deletedocument!(server, URI2(uri))
                         continue
                     end
         
@@ -35,22 +36,6 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                 doc = Document(uri, content, true, server)
                 setdocument!(server, URI2(uri), doc)
                 parse_all(doc, server)
-            end
-        elseif change.type == FileChangeTypes["Changed"]
-            doc = getdocument(server, URI2(uri))
-
-            # We only handle if currently not managed by client
-            if !get_open_in_editor(doc)
-                filepath = uri2filepath(uri)
-                content = try
-                    read(filepath, String)
-                catch err
-                    continue
-                end
-    
-                set_text!(doc, content)
-                set_is_workspace_file(doc, true)
-                parse_all(doc, server)                            
             end
         elseif change.type == FileChangeTypes["Deleted"]
             doc = getdocument(server, URI2(uri))

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -3,7 +3,11 @@ import StaticLint: getpath, setpath, getroot, setroot, getcst, setcst, scopepass
 hasfile(server::LanguageServerInstance, path::String) = hasdocument(server, URI2(filepath2uri(path)))
 canloadfile(server::LanguageServerInstance, path::String) = isfile(path)
 function loadfile(server::LanguageServerInstance, path::String)
-    source = read(path, String)
+    source = try
+        read(path, String)
+    catch err
+        return
+    end
     uri = filepath2uri(path)
     doc = Document(uri, source, true, server)
     StaticLint.setfile(server, path, doc)

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -4,7 +4,12 @@ hasfile(server::LanguageServerInstance, path::String) = hasdocument(server, URI2
 canloadfile(server::LanguageServerInstance, path::String) = isfile(path)
 function loadfile(server::LanguageServerInstance, path::String)
     source = try
-        read(path, String)
+        s = read(path, String)
+        # We throw an error in the case of an invalid
+        # UTF-8 sequence so that the same code path
+        # is used that handles file IO problems
+        isvalid(s) || error()
+        s
     catch err
         return
     end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -118,22 +118,8 @@ function get_toks(doc, offset)
 end
 
 function isvalidjlfile(path)
-    hasreadperm(path) && 
-    isfile(path) &&
-    endswith(path, ".jl") &&
-    validchars(path)
+    endswith(path, ".jl")
 end
-
-function validchars(path)
-    io = open(path)
-    while !eof(io)
-        c = read(io, Char)
-        Base.ismalformed(c) && return false
-    end
-    close(io)
-    return true
-end
-
 
 function get_expr(x, offset, pos = 0, ignorewhitespace = false)
     if pos > offset


### PR DESCRIPTION
This attempts to fix a whole bunch of file IO bugs that are coming in via crash reporting.

It generally takes a different approch from how we did this in the past: instead of trying to check various conditions before we try to read a file, we don't check anything anymore, but just try to read the file and wrap that in an exception handler.

I think the previous approch fundamtenally can't work reliably: there is always a chance that between our call to check for example file permissions and our read call, something changes about the file, and then the read call will fail. So we must just always have a try catch around the `read` operation, no matter what. But then we might as well do away with the checks as well, given that those scenarios then are also handled by the exception handler.

There were also crash reports where for example the call to the permission check failed. Maybe that was a situation where the file had been deleted between the LS notification that triggered this, and the permission check? But in any case, I think this approach here should just handle all of these situations.

~~The changes I made here _does_ remove the check for invalid UTF-8 sequences from the `isvalidjlf` function. I think we should just figure out what we want to do about that in https://github.com/julia-vscode/LanguageServer.jl/issues/563, and then handle it consistently in all situations. If we do want to add that check back in, we should just run it after every `read` call, rather than before we read the file.~~ This now also checks for invalid UTF-8 sequences everywhere where they might enter our system.

EDIT: I made two more changes:
1. I used the same code for create and changed file system notifications. I think that is more robust, in particular because we now need to make sure we handle change events properly even if we don't hold a copy of the doc already (in situations where the initial `read` failed).
2. ~~I added some code that checks whether a doc that is being deleted is a `root` anywhere else. Do we need to check more things in that situation? Like reparse something, trigger a new lint pass or something like that?~~ Removed this for now.