### PR TITLE
Add text sync diagnostics

### DIFF
--- a/src/exception_types.jl
+++ b/src/exception_types.jl
@@ -5,3 +5,11 @@ end
 function Base.showerror(io::IO, ex::LSSymbolServerFailure)
     print(io, ex.msg)
 end
+
+struct LSTextSyncError <: Exception
+    msg::AbstractString
+end
+
+function Base.showerror(io::IO, ex::LSTextSyncError)
+    print(io, ex.msg)
+end


### PR DESCRIPTION
Requires https://github.com/julia-vscode/julia-vscode/pull/1034.

As is not very useful, but the mechanics of getting the full text doc seem to work. I double checked, and if one types quickly, there are a fair number of requests where the version in the client is already ahead of the request, so we won't get a version all the time. But still, fingers crossed, we'll get something useful sometimes.

The real question is what extra fields we should include in the exception type, i.e. what kind of diagnostics are useful to receive in the crash report... Maybe the lenght of the doc, the offset positions, and then positions and length of each text edit?