### PR TITLE
Text sync diagnostic2

### DIFF
--- a/src/exception_types.jl
+++ b/src/exception_types.jl
@@ -5,3 +5,11 @@ end
 function Base.showerror(io::IO, ex::LSSymbolServerFailure)
     print(io, ex.msg)
 end
+
+struct LSTextSyncError <: Exception
+    msg::AbstractString
+end
+
+function Base.showerror(io::IO, ex::LSTextSyncError)
+    print(io, ex.msg)
+end

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -55,6 +55,8 @@ mutable struct LanguageServerInstance
 
     clientcapability_window_workdoneprogress::Bool
 
+    didChange_diags::Dict{String,Vector{Any}}
+
     function LanguageServerInstance(pipe_in, pipe_out, debug_mode::Bool = false, env_path = "", depot_path = "", err_handler=nothing)
         new(
             JSONRPCEndpoints.JSONRPCEndpoint(pipe_in, pipe_out, err_handler),
@@ -77,7 +79,8 @@ mutable struct LanguageServerInstance
             :created,
             0,
             nothing,
-            false
+            false,
+            Dict{String,Vector{Any}}()
         )
     end
 end


### PR DESCRIPTION
Extension of #579. 
Attempts to handle the server lagging behind the server. 

* When the client is ahead of the server it stores the the content changes (and before and after content). 
* When the server text and version matches that received from the client we clear the store.
* When the versions match between client and server but the text doesn't we dump the store (obscuring user text). (I'll then have to reconstruct what has happened in a fairly painful manner!)

This requires a change to https://github.com/julia-vscode/julia-vscode/pull/1034#event-3102414589 so that we always receive the latest version from the client, regardless of the version