### PR TITLE
Rework text sync

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -121,10 +121,7 @@ function get_offset2(doc::Document, line::Integer, character::Integer)
         pos = nextind(text, pos)        
     end
 
-    if pos>=next_line_offset
-        error("Invalid position")
-        ret = min(pos, next_line_offset)
-    end
+    ret = min(pos, next_line_offset)
 
     return pos
 end

--- a/src/document.jl
+++ b/src/document.jl
@@ -179,7 +179,7 @@ end
 
 function get_line_offsets2!(doc::Document, force = false)
     if force || doc._line_offsets2 === nothing
-        doc._line_offsets = Int[1]
+        doc._line_offsets2 = Int[1]
         text = get_text(doc)
         ind = firstindex(text)
         while ind <= lastindex(text)
@@ -188,14 +188,14 @@ function get_line_offsets2!(doc::Document, force = false)
                 if c == '\r' && ind + 1 <= lastindex(text) && text[ind + 1] == '\n'
                     ind += 1
                 end
-                push!(doc._line_offsets, ind + 1)
+                push!(doc._line_offsets2, ind + 1)
             end
             
             ind = nextind(text, ind)
         end
     end
 
-    return doc._line_offsets
+    return doc._line_offsets2
 end
 
 function get_line_of(line_offsets::Vector{Int}, offset::Integer)

--- a/src/document.jl
+++ b/src/document.jl
@@ -3,6 +3,7 @@ mutable struct Document
     path::String
     _content::String
     _line_offsets::Union{Nothing,Vector{Int}}
+    _line_offsets2::Union{Nothing,Vector{Int}}
     _open_in_editor::Bool
     _workspace_file::Bool
     cst::EXPR
@@ -14,8 +15,9 @@ mutable struct Document
     function Document(uri::AbstractString, text::AbstractString, workspace_file::Bool, server = nothing)
         path = uri2filepath(uri)
         cst = CSTParser.parse(text, true)
-        doc = new(uri, path, text, nothing, false, workspace_file, cst, [], 0, true, server, nothing)
+        doc = new(uri, path, text, nothing, nothing, false, workspace_file, cst, [], 0, true, server, nothing)
         get_line_offsets(doc)
+        get_line_offsets2!(doc)
         cst.val = path
         set_doc(doc.cst, doc)
         setroot(doc, doc)
@@ -93,6 +95,40 @@ end
 get_offset(doc, p::Position) = get_offset(doc, p.line, p.character)
 get_offset(doc, r::Range) = get_offset(doc, r.start):get_offset(doc, r.stop)
 
+function get_offset2(doc::Document, line::Integer, character::Integer)
+    line_offsets = get_line_offsets2!(doc)
+    text = get_text(doc)
+
+    if line >= length(line_offsets)
+        error("Invalid arguments.")
+        return nextind(text, lastindex(text))
+    elseif line < 0
+        error("Invalid arguments.")
+    end
+
+    line_offset = line_offsets[line+1]
+    
+    next_line_offset = line + 1 < length(line_offsets) ? line_offsets[line + 2] : nextind(text, lastindex(text))
+
+    pos = line_offset
+
+    while character>0
+        if UInt32(text[pos]) >= 0x010000
+            character -= 2
+        else
+            character -= 1
+        end
+        pos = nextind(text, pos)        
+    end
+
+    if pos>=next_line_offset
+        error("Invalid position")
+        ret = min(pos, next_line_offset)
+    end
+
+    return pos
+end
+
 # Note: to be removed
 function obscure_text(s)
     i = 1
@@ -139,6 +175,27 @@ function get_line_offsets(doc::Document, force = false)
             ind = nextind(text, ind)
         end
     end
+    return doc._line_offsets
+end
+
+function get_line_offsets2!(doc::Document, force = false)
+    if force || doc._line_offsets2 === nothing
+        doc._line_offsets = Int[1]
+        text = get_text(doc)
+        ind = firstindex(text)
+        while ind <= lastindex(text)
+            c = text[ind]
+            if c == '\n' || c == '\r'
+                if c == '\r' && ind + 1 <= lastindex(text) && text[ind + 1] == '\n'
+                    ind += 1
+                end
+                push!(doc._line_offsets, ind + 1)
+            end
+            
+            ind = nextind(text, ind)
+        end
+    end
+
     return doc._line_offsets
 end
 

--- a/src/document.jl
+++ b/src/document.jl
@@ -40,6 +40,8 @@ end
 
 function set_text!(doc::Document, text)
     doc._content = text
+    doc._line_offsets = nothing
+    doc._line_offsets2 = nothing
 end
 
 function set_open_in_editor(doc::Document, value::Bool)
@@ -221,7 +223,7 @@ byte offset.
 function get_position_at(doc::Document, offset::Integer)
     offset > sizeof(get_text(doc)) && error("offset[$offset] > sizeof(content)[$(sizeof(get_text(doc)))]") # OK, offset comes from EXPR spans
     line_offsets = get_line_offsets(doc)
-    line, ind = get_line_of(doc._line_offsets, offset)
+    line, ind = get_line_of(line_offsets, offset)
     io = IOBuffer(get_text(doc))
     seek(io, line_offsets[line])
     character = 0

--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -192,9 +192,10 @@ function get_next_line_offset(x)
     file, offset = get_file_loc(x)
     # get next line after using_stmt
     insertpos = -1
-    for i = 1:length(file._line_offsets) - 1
-        if file._line_offsets[i] < offset + x.span <= file._line_offsets[i + 1]
-            insertpos = file._line_offsets[i + 1]
+    line_offsets = get_line_offsets(file)
+    for i = 1:length(line_offsets) - 1
+        if line_offsets[i] < offset + x.span <= line_offsets[i + 1]
+            insertpos = line_offsets[i + 1]
         end
     end
     return insertpos

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -223,6 +223,9 @@ function convert_lsrange_to_jlrange(doc::Document, range::Range)
 
     text = get_text(doc)
     
+    # we use prevind for the stop value here because Julia stop values in
+    # a range are inclusive, while the stop value is exclusive in a LS
+    # range
     return start_offset_ls:prevind(text, stop_offset)
 end
 
@@ -232,9 +235,11 @@ function applytextdocumentchanges(doc::Document, tdcce::TextDocumentContentChang
         set_text!(doc, tdcce.text)
     else
         editrange = convert_lsrange_to_jlrange(doc, tdcce.range)
+
         text = get_text(doc)
 
         new_text = string(text[1:prevind(text, editrange.start)], tdcce.text, text[nextind(text, editrange.stop):lastindex(text)])
+
         set_text!(doc, new_text)
     end
     doc._line_offsets = nothing


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/564. Or at least I hope it does ;)

I essentially started from the code at https://github.com/microsoft/vscode-languageserver-node/blob/master/textDocument/src/main.ts and ported that over to Julia.

The main difference to the previous implementation is that offset is now always a valid Julia string index. The range in the edit chunk is the text that gets replaced (expressed as a Julia range that returns that text if used to index into the String). Generally the code is simplified, fewer `if` `else` stories in the whole `didChange` story, hopefully that makes this more robust.

I've only changed the text sync stuff over to the new offset interpretation, everything else still uses the old version. Not ideal, but I thought maybe we should first try and see whether this actually works or not...

This also replaces https://github.com/julia-vscode/LanguageServer.jl/pull/582 by incorporating most of it.

I think before we invest more time into the various diagnostic PRs we created, we should maybe just try to ship this PR here in our insider build and see whether the problem just goes away. If not, we can still go back to trying to figure out what is going on with the old code.