### PR TITLE
Don't crash the LS when the SymServer crashes

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -153,11 +153,12 @@ function trigger_symbolstore_reload(server::LanguageServerInstance)
         if ssi_ret==:success
             push!(server.symbol_results_channel, payload)
         elseif ssi_ret==:failure
-            if payload===nothing
-                throw(LSSymbolServerFailure(""))
-            else
-                throw(LSSymbolServerFailure(String(take!(payload))))
-            end
+            error_payload = Dict(
+                "command"=>"symserv_crash",
+                "name"=>"LSSymbolServerFailure",
+                "message"=>payload===nothing ? "" : String(take!(payload)),
+                "stacktrace"=>"")
+                JSONRPCEndpoints.send_notification(server.jr_endpoint, "telemetry/event", error_payload)
         end
         server.symbol_store_ready = true
     catch err


### PR DESCRIPTION
With this we still get crash reports when the symbol server process crashes, but it won't take the LS process down anymore. Instead, the LS process will just not have returned the symbol info we need, but other parts of the LS should still work.