### PR TITLE
Fix UTF-8 validation and file IO error checking

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -92,10 +92,7 @@ function load_folder(path::String, server)
                         else
                             content = try
                                 s = read(filepath, String)
-                                # We throw an error in the case of an invalid
-                                # UTF-8 sequence so that the same code path
-                                # is used that handles file IO problems
-                                isvalid(s) || error()
+                                isvalid(s) || continue
                                 s
                             catch err
                                 isa(err, Base.IOError) || rethrow()

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -402,10 +402,7 @@ function search_for_parent(dir::String, file::String, drop = 3, parents = String
             # Could be sped up?            
             content = try
                 s = read(filename, String)
-                # We throw an error in the case of an invalid
-                # UTF-8 sequence so that the same code path
-                # is used that handles file IO problems
-                isvalid(s) || error()
+                isvalid(s) || continue
                 s
             catch err
                 isa(err, Base.IOError) || rethrow()
@@ -427,10 +424,7 @@ function is_parentof(parent_path, child_path, server)
     if !hasdocument(server, URI2(puri))
         content = try
             s = read(parent_path, String)
-            # We throw an error in the case of an invalid
-            # UTF-8 sequence so that the same code path
-            # is used that handles file IO problems
-            isvalid(s) || error()
+            isvalid(s) || return false
             s
         catch err
             isa(err, Base.IOError) || rethrow()

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -16,10 +16,10 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                     filepath = uri2filepath(uri)
                     content = try
                         s = read(filepath, String)
-                        # We throw an error in the case of an invalid
-                        # UTF-8 sequence so that the same code path
-                        # is used that handles file IO problems
-                        isvalid(s) || error()
+                        if !isvalid(s)
+                            deletedocument!(server, URI2(uri))
+                            continue
+                        end
                         s
                     catch err
                         isa(err, Base.IOError) || rethrow()
@@ -35,10 +35,7 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                 filepath = uri2filepath(uri)
                 content = try
                     s = read(filepath, String)
-                    # We throw an error in the case of an invalid
-                    # UTF-8 sequence so that the same code path
-                    # is used that handles file IO problems
-                    isvalid(s) || error()
+                    isvalid(s) || continue
                     s
                 catch err
                     isa(err, Base.IOError) || rethrow()

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -12,10 +12,7 @@ end
 function loadfile(server::LanguageServerInstance, path::String)
     source = try
         s = read(path, String)
-        # We throw an error in the case of an invalid
-        # UTF-8 sequence so that the same code path
-        # is used that handles file IO problems
-        isvalid(s) || error()
+        isvalid(s) || return
         s
     catch err
         isa(err, Base.IOError) || rethrow()


### PR DESCRIPTION
When I added the more specific error handlers, I forgot to also adjust the validation phase accordingly. Fixes a bug from crash reporting.

I added some stuff, namely it is now also handling `SystemError` properly, because those can also happen from file IO problems.