### PR TITLE
Fix file IO error handling

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -3,7 +3,7 @@ function _ispath(s::String)
     try
         return ispath(s)
     catch err
-        isa(err, Base.IOError) || rethrow()
+        isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
         return false
     end
 end

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -84,7 +84,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/definition")},TextD
                         push!(locations, Location(filepath2uri(m.file), Range(m.line - 1, 0, m.line -1, 0)))
                     end
                 catch err
-                    isa(err, Base.IOError) || rethrow()
+                    isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
                 end
             end
         elseif b isa StaticLint.Binding && b.val isa StaticLint.Binding
@@ -119,7 +119,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/definition")},TextD
                     push!(locations, Location(filepath2uri(joinpath(dirname(uri2filepath(doc._uri)), valof(x))), Range(0, 0, 0, 0)))
                 end
             catch err
-                isa(err, Base.IOError) || rethrow()
+                isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
             end
         end
     end

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -57,7 +57,7 @@ function has_too_many_files(path, N = 5000)
             end
         end
     catch err
-        isa(err, Base.IOError) || rethrow()
+        isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
         return false
     end
 
@@ -95,7 +95,7 @@ function load_folder(path::String, server)
                                 isvalid(s) || continue
                                 s
                             catch err
-                                isa(err, Base.IOError) || rethrow()
+                                isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
                                 continue
                             end
                             doc = Document(uri, content, true, server)
@@ -106,7 +106,7 @@ function load_folder(path::String, server)
                 end
             end
         catch err
-            isa(err, Base.IOError) || rethrow()
+            isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
         end
     end
 end

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -405,7 +405,7 @@ function search_for_parent(dir::String, file::String, drop = 3, parents = String
                 isvalid(s) || continue
                 s
             catch err
-                isa(err, Base.IOError) || rethrow()
+                isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
                 continue
             end
             occursin(file, content) && push!(parents, joinpath(dir, f))
@@ -427,7 +427,7 @@ function is_parentof(parent_path, child_path, server)
             isvalid(s) || return false
             s
         catch err
-            isa(err, Base.IOError) || rethrow()
+            isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
             return false
         end
         pdoc = Document(puri, content, false, server)

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -22,7 +22,7 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                         end
                         s
                     catch err
-                        isa(err, Base.IOError) || rethrow()
+                        isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
                         deletedocument!(server, URI2(uri))
                         continue
                     end
@@ -38,7 +38,7 @@ function process(r::JSONRPC.Request{Val{Symbol("workspace/didChangeWatchedFiles"
                     isvalid(s) || continue
                     s
                 catch err
-                    isa(err, Base.IOError) || rethrow()
+                    isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
                     continue
                 end
     

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -5,7 +5,7 @@ function canloadfile(server::LanguageServerInstance, path::String)
     try
         return isfile(path)
     catch err
-        isa(err, Base.IOError) || rethrow()
+        isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
         return false
     end
 end
@@ -15,7 +15,7 @@ function loadfile(server::LanguageServerInstance, path::String)
         isvalid(s) || return
         s
     catch err
-        isa(err, Base.IOError) || rethrow()
+        isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
         return
     end
     uri = filepath2uri(path)


### PR DESCRIPTION
Argh, this was meant to be part of the previous PR... 

In any case, we need to treat `IOError` and `SystemError` the same way, both can happen with file IO problems.