### PR TITLE
Remove textDocument/definition for paths in strings

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -110,18 +110,6 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/definition")},TextD
                 b = nothing
             end
         end
-    elseif x isa EXPR && typof(x) === CSTParser.LITERAL && (kindof(x) === Tokens.STRING || kindof(x) === Tokens.TRIPLE_STRING)
-        if sizeof(valof(x)) < 256 # AUDIT: OK
-            try
-                if isfile(valof(x))
-                    push!(locations, Location(filepath2uri(valof(x)), Range(0, 0, 0, 0)))
-                elseif isfile(joinpath(dirname(uri2filepath(doc._uri)), valof(x)))
-                    push!(locations, Location(filepath2uri(joinpath(dirname(uri2filepath(doc._uri)), valof(x))), Range(0, 0, 0, 0)))
-                end
-            catch err
-                isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
-            end
-        end
     end
     
     return locations


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/594, by removing the feature entirely :)

I think we shouldn't have this irrespective of the bug, the semantics of goto definition are pretty clear in my mind, and following strings if they are filenames doesn't seem to fall under that. I also checked this, and for example the typescript extension also doesn't do that.