### PR TITLE
Add exception type for failed uri conversions

### DIFF
--- a/src/exception_types.jl
+++ b/src/exception_types.jl
@@ -5,3 +5,11 @@ end
 function Base.showerror(io::IO, ex::LSSymbolServerFailure)
     print(io, ex.msg)
 end
+
+struct LSUriConversionFailure <: Exception
+    msg::AbstractString
+end
+
+function Base.showerror(io::IO, ex::LSUriConversionFailure)
+    print(io, ex.msg)
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,5 +1,11 @@
 function uri2filepath(uri::AbstractString)
-    uri_path = normpath(URIParser.unescape(URIParser.URI(uri).path))
+    parsed_uri = try
+        URIParser.URI(uri)
+    catch err
+        throw(LSUriConversionFailure("Cannot parse `$uri`."))
+    end
+
+    uri_path = normpath(URIParser.unescape(parsed_uri.path))
 
     if Sys.iswindows()
         if uri_path[1] == '\\' || uri_path[1] == '/'


### PR DESCRIPTION
We have some crash reports where the conversion doesn't work, this adds some diagnostics to our crash reports that hopefully will allow us to figure out what is going on.