### PR TITLE
mark var"" missings

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -209,6 +209,24 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/rename")},RenamePar
 end
 
 
+is_valid_binding_name(name) = false
+function is_valid_binding_name(name::EXPR)
+    (typof(name) === CSTParser.IDENTIFIER && valof(name) isa String && !isempty(valof(name))) ||
+    (typof(name) === CSTParser.OPERATOR) ||
+    (typof(name) === CSTParser.NONSTDIDENTIFIER && length(name) == 2 && valof(name[2]) isa String && !isempty(valof(name[2])))
+end
+function get_name_of_binding(name::EXPR) 
+    if typof(name) === CSTParser.IDENTIFIER
+        valof(name)
+    elseif typof(name) === CSTParser.OPERATOR
+        string(Expr(name))
+    elseif typof(name) === CSTParser.NONSTDIDENTIFIER
+        valof(name[2])
+    else
+        ""
+    end
+end
+
 JSONRPC.parse_params(::Type{Val{Symbol("textDocument/documentSymbol")}}, params) = DocumentSymbolParams(params) 
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/documentSymbol")},DocumentSymbolParams}, server) 
     syms = SymbolInformation[]
@@ -219,8 +237,8 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/documentSymbol")},D
     for x in bs
         p,b = x[1], x[2]
         !(b.val isa EXPR) && continue
-        (valof(b.name) === nothing || isempty(valof(b.name))) && typof(b.name) !== CSTParser.OPERATOR && continue
-        push!(syms, SymbolInformation(typof(b.name) === CSTParser.OPERATOR ? string(Expr(b.name)) : valof(b.name), _binding_kind(b, server), false, Location(doc._uri, Range(doc, p)), missing))
+        !is_valid_binding_name(b.name) && continue
+        push!(syms, SymbolInformation(get_name_of_binding(b.name), _binding_kind(b, server), false, Location(doc._uri, Range(doc, p)), missing))
     end
     return syms
 end

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -300,7 +300,7 @@ function mark_errors(doc, out = Diagnostic[])
                 else
                     if typof(errs[i][2]) === CSTParser.ErrorToken
                         push!(out, Diagnostic(Range(r[1] - 1, r[2], line - 1, char), 1, "Julia", "Julia", "Parsing error", missing, missing))
-                    elseif typof(errs[i][2]) === CSTParser.IDENTIFIER && !StaticLint.haserror(errs[i][2])
+                    elseif CSTParser.isidentifier(errs[i][2]) && !StaticLint.haserror(errs[i][2])
                         push!(out, Diagnostic(Range(r[1] - 1, r[2], line - 1, char), 2, "Julia", "Julia", "Missing reference: $(errs[i][2].val)", missing, missing))
                     elseif StaticLint.haserror(errs[i][2]) && StaticLint.errorof(errs[i][2]) isa StaticLint.LintCodes
                         push!(out, Diagnostic(Range(r[1] - 1, r[2], line - 1, char), 3, "Julia", "Julia", get(StaticLint.LintCodeDescriptions, StaticLint.errorof(errs[i][2]), ""), missing, missing))


### PR DESCRIPTION
Marking missing Symbols that use `var"something"` syntax