### PR TITLE
Support UNC paths

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ DocumentFormat = "2.1"
 StaticLint = "4"
 Tokenize = "0.5.7"
 SymbolServer = "4"
-URIParser = "0.4.0"
+URIParser = "0.4.1"
 
 [targets]
 test = ["Test", "Sockets", "Pkg", "LibGit2", "Serialization", "SHA"]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -5,14 +5,32 @@ function uri2filepath(uri::AbstractString)
         throw(LSUriConversionFailure("Cannot parse `$uri`."))
     end
 
-    uri_path = normpath(URIParser.unescape(parsed_uri.path))
+    path_unescaped = URIParser.unescape(parsed_uri.path)
+    host_unescaped = URIParser.unescape(parsed_uri.host)
+
+    value = ""
+
+    if host_unescaped!="" && length(path_unescaped)>1 && parsed_uri.scheme=="file"
+        # unc path: file://shares/c$/far/boo
+        value = "//$host_unescaped$path_unescaped"
+    elseif length(path_unescaped)>=3 &&
+            path_unescaped[1]=='/' &&
+            isascii(path_unescaped[2]) && isletter(path_unescaped[2]) &&
+            path_unescaped[3]==':'
+        # windows drive letter: file:///c:/far/boo
+        value = lowercase(path_unescaped[2]) * path_unescaped[3:end]
+    else
+        # other path
+        value = path_unescaped
+    end
+
+    value = normpath(value)
 
     if Sys.iswindows()
-        if uri_path[1] == '\\' || uri_path[1] == '/'
-            uri_path = uri_path[2:end]
-        end
+        value = replace(value, '/' => '\\')
     end
-    return uri_path
+
+    return value
 end
 
 function filepath2uri(file::String)
@@ -21,7 +39,13 @@ function filepath2uri(file::String)
         file = replace(file, "\\" => "/")
         file = URIParser.escape(file)
         file = replace(file, "%2F" => "/")
-        return string("file:///", file)
+        if startswith(file, "//")
+            # UNC path \\foo\bar\foobar
+            return string("file://",file[3:end])
+        else
+            # windows drive letter path
+            return string("file:///", file)
+        end
     else
         file = normpath(file)
         file = URIParser.escape(file)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -24,11 +24,11 @@ function uri2filepath(uri::AbstractString)
         value = path_unescaped
     end
 
-    value = normpath(value)
-
     if Sys.iswindows()
         value = replace(value, '/' => '\\')
     end
+
+    value = normpath(value)
 
     return value
 end

--- a/test/test_paths.jl
+++ b/test/test_paths.jl
@@ -1,0 +1,21 @@
+using Test
+using LanguageServer
+
+@testset "URI conversion" begin
+
+if Sys.iswindows
+    @test LanguageServer.uri2filepath("file://SERVER/foo/bar") == "\\\\SERVER\\foo\\bar"
+    @test LanguageServer.uri2filepath("file://wsl%24/foo/bar") == "\\\\wsl\$\\foo\\bar"
+    @test LanguageServer.uri2filepath("file:///D:/foo/bar") == "d:\\foo\\bar"
+    @test LanguageServer.uri2filepath("file:///foo/bar") == "\\foo\\bar"
+
+    @test LanguageServer.filepath2uri("\\\\SERVER\\foo\\bar") == "file://SERVER/foo/bar"
+    @test LanguageServer.filepath2uri("\\\\wsl\$\\foo\\bar") == "file://wsl%24/foo/bar"
+    @test LanguageServer.filepath2uri("d:\\foo\\bar") == "file:///d%3A/foo/bar"    
+else
+    @test LanguageServer.uri2filepath("file:///foo/bar") == "/foo/bar"
+
+    @test LanguageServer.filepath2uri("/foo/bar") == "file:///foo/bar"
+end
+
+end


### PR DESCRIPTION
~~This first requires a new version of URIParser with https://github.com/JuliaWeb/URIParser.jl/pull/68 merged.~~ New version of URIParser.jl is published.

In general this is the first step to support UNC paths on Windows. We currently have crash reports around that.

I mostly just followed the logic of the URI node package that VS Code uses.