### PR TITLE
Register for didChangeConfiguration

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -55,6 +55,7 @@ mutable struct LanguageServerInstance
     current_symserver_progress_token::Union{Nothing,String}
 
     clientcapability_window_workdoneprogress::Bool
+    clientcapability_workspace_didChangeConfiguration::Bool
 
     function LanguageServerInstance(pipe_in, pipe_out, debug_mode::Bool = false, env_path = "", depot_path = "", err_handler=nothing)
         new(
@@ -79,6 +80,7 @@ mutable struct LanguageServerInstance
             :created,
             0,
             nothing,
+            false,
             false
         )
     end


### PR DESCRIPTION
I think this is how we are supposed to do this right now.

What is weird is that we then get a change notification for _any_ setting change (even say in the Python extension), but I don't think that should cause any problems. I have a question out to MS how we are supposed to handle that, but I think this PR in itself is correct already and we should just go ahead and merge to see whether this might solve the errors we get in crash reporting on this stuff.

Also needs https://github.com/julia-vscode/julia-vscode/pull/1157.