### PR TITLE
Add a request for help to tricky bug

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -76,6 +76,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didSave")},DidSaveT
     doc = getdocument(server, URI2(uri))
     if r.params.text isa String
         if get_text(doc) != r.params.text
+            JSONRPCEndpoints.send_notification(server.jr_endpoint, "window/showMessage", ShowMessageParams(MessageTypes.Error, "Julia Extension: Please contact us! Your extension just crashed with a bug that we have been trying to replicate for a long time. You could help the development team a lot by contacting us at https://github.com/julia-vscode/julia-vscode so that we can work together to fix this issue."))
             throw(LSSyncMismatch("Mismatch between server and client text for $(doc._uri). _open_in_editor is $(doc._open_in_editor). _workspace_file is $(doc._workspace_file). _version is $(doc._version)."))
         end
     end


### PR DESCRIPTION
We are still seeing bugs in that part in the crash reporting... The weird thing is that we get the error for files that are not open in the editor, which I don't even understand how that is possible at all....

In any case, I'm out of ideas what might be wrong here, but maybe we can track it down if we can ask for more information...