### PR TITLE
Refactor ternary expressions to plain get

### DIFF
--- a/src/jsonrpc.jl
+++ b/src/jsonrpc.jl
@@ -39,7 +39,7 @@ function parse(::Type{Request}, message_dict::Dict)
     if message_dict["jsonrpc"] != "2.0"
         error("Invalid JSON-RPC version")
     end
-    id = haskey(message_dict, "id") ? message_dict["id"] : nothing
+    id = get(message_dict, "id", nothing)
     method = Val{Symbol(message_dict["method"])}
     params = message_dict["params"]
 

--- a/src/jsonrpcendpoint.jl
+++ b/src/jsonrpcendpoint.jl
@@ -157,7 +157,7 @@ function send_request(x::JSONRPCEndpoint, method::AbstractString, params)
     elseif haskey(response, "error")
         error_code = response["error"]["code"]
         error_msg = response["error"]["message"]
-        error_data = haskey(response["error"], "data") ? response["error"]["code"] : nothing
+        error_data = get(response["error"], "data", nothing)
         throw(JSONRPCError(error_code, error_msg, error_data))
     else
         throw(JSONRPCError(0, "ERROR AT THE TRANSPORT LEVEL", nothing))

--- a/src/protocol/initialize.jl
+++ b/src/protocol/initialize.jl
@@ -112,7 +112,7 @@ function InitializeParams(dict::Dict)
     haskey(dict, "clientInfo") ? InfoParams(dict["clientInfo"]) : missing,
     !haskey(dict, "rootPath") ? missing : dict["rootPath"] === nothing ? nothing : DocumentUri(dict["rootPath"]),
     dict["rootUri"] === nothing ? nothing : DocumentUri(dict["rootUri"]), 
-    haskey(dict, "initializationOptions") ? dict["initializationOptions"] : missing , 
+    get(dict, "initializationOptions", missing),
     ClientCapabilities(dict["capabilities"]), 
     haskey(dict, "trace") ? String(dict["trace"]) : missing ,
     !haskey(dict, "workspaceFolders") ? missing : dict["workspaceFolders"] === nothing ? nothing : WorkspaceFolder.(dict["workspaceFolders"]),


### PR DESCRIPTION
This saves a dictionary lookup and is easier to read. This also may
make debugging #600 easier since there was a bug where
`response["error"]["data"]` was getting thrown away and
`response["error"]["code"]` used instead.