### PR TITLE
Don't send missing fields

### DIFF
--- a/src/protocol/basic.jl
+++ b/src/protocol/basic.jl
@@ -81,7 +81,7 @@ end
 
 ##############################################################################
 
-struct Command <: HasMissingFields # Use traits for this?
+struct Command <: Outbound # Use traits for this?
     title::String
     command::String
     arguments::Union{Vector{Any},Missing}

--- a/src/protocol/protocol.jl
+++ b/src/protocol/protocol.jl
@@ -1,7 +1,6 @@
 abstract type Outbound end
-abstract type HasMissingFields end
 
-function JSON.Writer.CompositeTypeWrapper(t::HasMissingFields)
+function JSON.Writer.CompositeTypeWrapper(t::Outbound)
     fns = collect(fieldnames(typeof(t)))
     dels = Int[]
     for i = 1:length(fns)


### PR DESCRIPTION
For some reason we were sending fields specified as missing in the  LSP to the client.

hat tip: @non-Jedi 