### PR TITLE
Simplify configuration code

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -264,10 +264,7 @@ function Base.run(server::LanguageServerInstance)
                     scopepass(root, doc)
                 end
 
-                StaticLint.check_all(getcst(doc), server.lint_options, server)
-                empty!(doc.diagnostics)
-                mark_errors(doc, doc.diagnostics)
-                publish_diagnostics(doc, server)
+                lint!(doc, server)
             end
         end
     end

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -80,10 +80,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didChange")},DidCha
         tdcce = first(r.params.contentChanges)
         new_cst = _partial_update(doc, tdcce) 
         scopepass(getroot(doc), doc)
-        StaticLint.check_all(getcst(doc), server.lint_options, server)
-        empty!(doc.diagnostics)
-        mark_errors(doc, doc.diagnostics)
-        publish_diagnostics(doc, server)
+        lint!(doc, server)
     else
         for tdcce in r.params.contentChanges
             applytextdocumentchanges(doc, tdcce)
@@ -234,11 +231,7 @@ function parse_all(doc::Document, server::LanguageServerInstance)
     end
     
     scopepass(getroot(doc), doc)
-    StaticLint.check_all(getcst(doc), server.lint_options, server)
-    empty!(doc.diagnostics)
-    mark_errors(doc, doc.diagnostics)
-    
-    publish_diagnostics(doc, server)
+    lint!(doc, server)
 end
 
 function mark_errors(doc, out = Diagnostic[])

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -100,19 +100,18 @@ function request_julia_config(server::LanguageServerInstance)
         ConfigurationItem(missing, "julia.lint.missingrefs")
         ]))
 
-    new_DF_opts = DocumentFormat.FormatOptions([isnothing(opt) ? DocumentFormat.default_options[i] : opt for (i,opt) in enumerate(response[1:11])]...)
-    new_SL_opts = StaticLint.LintOptions([isnothing(opt) ? StaticLint.default_options[i] : opt for (i,opt) in enumerate(response[12:21])]...)
-    new_lintrun = isnothing(response[22]) ? true : response[22]
-    new_missingref = isnothing(response[23]) ? :all : Symbol(response[23])
-    
+    server.format_options = DocumentFormat.FormatOptions(response[1:11]...)
+    server.runlinter = something(response[22], true)
+    server.lint_missingrefs = Symbol(something(response[23], :all))
+
+    new_SL_opts = StaticLint.LintOptions(response[12:21]...)
+    # TODO: implement == for StaticLint.LintOptions
     rerun_lint = any(getproperty(server.lint_options, opt) != getproperty(new_SL_opts, opt) for opt in fieldnames(StaticLint.LintOptions))
-    server.format_options = new_DF_opts
     server.lint_options = new_SL_opts
-    server.runlinter = new_lintrun
-    server.lint_missingrefs = new_missingref
 
     if rerun_lint
         for doc in getdocuments_value(server)
+            # TODO: wrap next 4 lines in function since it's repeated throughout project
             StaticLint.check_all(getcst(doc), server.lint_options, server)
             empty!(doc.diagnostics)
             mark_errors(doc, doc.diagnostics)

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -111,11 +111,7 @@ function request_julia_config(server::LanguageServerInstance)
 
     if rerun_lint
         for doc in getdocuments_value(server)
-            # TODO: wrap next 4 lines in function since it's repeated throughout project
-            StaticLint.check_all(getcst(doc), server.lint_options, server)
-            empty!(doc.diagnostics)
-            mark_errors(doc, doc.diagnostics)
-            publish_diagnostics(doc, server)
+            lint!(doc, server)
         end
     end
 

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -57,3 +57,10 @@ function setserver(file::Document, server::LanguageServerInstance)
     file.server = server
     return file
 end
+
+function lint!(doc, server)
+    StaticLint.check_all(getcst(doc), server.lint_options, server)
+    empty!(doc.diagnostics)
+    mark_errors(doc, doc.diagnostics)
+    publish_diagnostics(doc, server)
+end


### PR DESCRIPTION
Simplified version of #683 or #666. Also did a bit of
refactoring. This avoids using `default_options` from StaticLint and
DocumentFormat which probably shouldn't be considered part of their
public API.