### PR TITLE
add PackageCompile project and compilation script

### DIFF
--- a/contrib/.gitignore
+++ b/contrib/.gitignore
@@ -1,0 +1,1 @@
+JuliaLSP_compiled

--- a/contrib/JuliaLSP/Project.toml
+++ b/contrib/JuliaLSP/Project.toml
@@ -1,0 +1,8 @@
+name = "JuliaLSP"
+uuid = "9488cb22-ff86-4d62-8f4a-077fe1791049"
+authors = ["Matsievskiy S.V. <matsievskiysv@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+LanguageServer = "2b0e0bc5-e4fd-59b4-8912-456d1b03d8d7"
+SymbolServer = "cf896787-08d5-524d-9de7-132aaa0cb996"

--- a/contrib/JuliaLSP/precompile_app.jl
+++ b/contrib/JuliaLSP/precompile_app.jl
@@ -1,0 +1,4 @@
+using JuliaLSP
+
+push!(ARGS, "arg")
+JuliaLSP.julia_main()

--- a/contrib/JuliaLSP/src/JuliaLSP.jl
+++ b/contrib/JuliaLSP/src/JuliaLSP.jl
@@ -1,0 +1,13 @@
+module JuliaLSP
+
+using LanguageServer
+import SymbolServer
+
+function julia_main()::Cint
+    server = LanguageServer.LanguageServerInstance(stdin, stdout)
+    server.runlinter = true
+    run(server)
+    return 0 # if things finished successfully
+end
+
+end # module

--- a/contrib/compile.sh
+++ b/contrib/compile.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+JULIABIN="julia"
+JULIAPROJ="JuliaLSP"
+JULIACOMP="JuliaLSP_compiled"
+
+BRANCH="master"
+
+RED='\033[0;31m'
+NC='\033[0m'
+
+while [[ $# -gt 0 ]]
+    do
+    key="$1"
+
+    case $key in
+        -j|--julia)
+            JULIABIN="$2"
+            shift
+        ;;
+        -b|--branch)
+            BRANCH="$2"
+            shift
+        ;;
+        *)
+            echo -e "Usage:\ncompile.sh [-j|--julia <julia binary>] [-b|--branch <repo branch>]" >&2
+            exit
+        ;;
+    esac
+    shift
+done
+
+echo -e ${RED}Updating packages${NC}
+
+$JULIABIN --startup-file=no --history-file=no -e \
+          "import Pkg; Pkg.activate(\"${JULIAPROJ}\"); Pkg.add(Pkg.PackageSpec(url=\"https://github.com/julia-vscode/LanguageServer.jl\", rev=\"${BRANCH}\")); Pkg.update();" || exit
+
+echo -e ${RED}Compiling...${NC}
+
+$JULIABIN --startup-file=no --history-file=no -e \
+          "import Pkg; Pkg.add(\"PackageCompiler\"); using PackageCompiler; create_app(\"${JULIAPROJ}\", \"${JULIACOMP}\", force=true);" || exit
+
+echo -e ${RED}Compiled${NC}


### PR DESCRIPTION
This PR adds [PackageCompiler](https://github.com/JuliaLang/PackageCompiler.jl) project that allows to compile LanguageServer into binary file. Compilation script may simplify process for people unfamiliar with PackageCompiler.

This may be used to generate [binary releases](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository).