### PR TITLE
Add escaping when comparing/hashing URI2

### DIFF
--- a/src/uri2.jl
+++ b/src/uri2.jl
@@ -11,23 +11,23 @@ import Base.==
 function ==(a::URI2, b::URI2)
     @static if Sys.iswindows()
         if startswith(a._uri, "file://")
-            return lowercase(a._uri) == lowercase(b._uri)
+            return lowercase(escape_uri(a._uri)) == lowercase(escape_uri(b._uri))
         else
             return a._uri == b._uri
         end
     else
-        return a._uri == b._uri
+        return escape_uri(a._uri) == escape_uri(b._uri)
     end
 end
 
 function Base.hash(a::URI2, h::UInt)
     @static if Sys.iswindows()
         if startswith(a._uri, "file://")
-            return hash(lowercase(a._uri), h)
+            return hash(lowercase(escape_uri(a._uri)), h)
         else
             return hash(a._uri)
         end
     else
-        return hash(a._uri)
+        return hash(escape_uri(a._uri))
     end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -54,6 +54,13 @@ function filepath2uri(file::String)
     end
 end
 
+function escape_uri(uri::AbstractString)
+    if !startswith(uri, "file://") # escaping only file URI
+        return uri
+    end
+    escaped_uri = uri[8:end] |> URIParser.unescape |> URIParser.escape
+    return string("file://", replace(escaped_uri, "%2F" => "/"))
+end
 
 function should_file_be_linted(uri, server)
     !server.runlinter && return false

--- a/test/test_paths.jl
+++ b/test/test_paths.jl
@@ -19,3 +19,29 @@ else
 end
 
 end
+
+@testset "URI comparison" begin
+
+if Sys.iswindows()
+    @test LanguageServer.escape_uri("file:///c:/foo/bar") == "file:///c%3A/foo/bar"
+    @test LanguageServer.escape_uri("file://wsl%24/foo/bar") == "file://wsl%24/foo/bar"
+    @test LanguageServer.escape_uri("file:///D:/FOO/bar") == "file:///D%3A/FOO/bar"
+
+    @test hash(LanguageServer.URI2("file:///D:/FOO/bar")) == hash(LanguageServer.URI2("file:///d%3A/FOO/bar"))
+    @test hash(LanguageServer.URI2("file:///C:/foo/space bar")) == hash(LanguageServer.URI2("file:///c%3A/foo/space%20bar"))
+    @test hash(LanguageServer.URI2("file://wsl\$/foo/bar")) == hash(LanguageServer.URI2("file://wsl%24/foo/bar"))
+
+    @test LanguageServer.URI2("file:///D:/FOO/bar") == LanguageServer.URI2("file:///d%3A/FOO/bar")
+    @test LanguageServer.URI2("file:///C:/foo/space bar") == LanguageServer.URI2("file:///c%3A/foo/space%20bar")
+    @test LanguageServer.URI2("file://wsl\$/foo/bar") == LanguageServer.URI2("file://wsl%24/foo/bar")
+else
+    @test LanguageServer.escape_uri("file:///foo/bar") == "file:///foo/bar"
+
+    @test hash(LanguageServer.URI2("file:///foo/bar")) == hash(LanguageServer.URI2("file:///foo/bar"))
+    @test hash(LanguageServer.URI2("file:///foo/space bar")) == hash(LanguageServer.URI2("file:///foo/space%20bar"))
+
+    @test LanguageServer.URI2("file:///foo/bar") == LanguageServer.URI2("file:///foo/bar")
+    @test LanguageServer.URI2("file:///foo/space bar") == LanguageServer.URI2("file:///foo/space%20bar")
+end
+
+end


### PR DESCRIPTION
- Add function for escaping URI
- Add tests for escaping/comparing/hashing URI

This is a continuation of discussion in #699 PR, that allows comparing URIs that were created using different encoding schemes.
Basically what it does is it escapes URI to bring it to the same encoding scheme as in [vscode-uri](https://github.com/Microsoft/vscode-uri).
This allows for following comparisons:
```julia
hash(LanguageServer.URI2("file:///D:/FOO/bar")) == hash(LanguageServer.URI2("file:///d%3A/FOO/bar"))
```

It escapes only file URI, since I'm not sure if escaping is needed in other cases.

**Note:** It still needs to be checked if _"VS Code internally also treats two strings that stand for the same URI but use different encoding patterns as equal or not"_, so this may be considered as WIP.
