### PR TITLE
Add check for relative paths

### DIFF
--- a/src/exception_types.jl
+++ b/src/exception_types.jl
@@ -45,3 +45,11 @@ end
 function Base.showerror(io::IO, ex::LSPositionToOffsetException)
     print(io, ex.msg)
 end
+
+struct LSRelativePath <:Exception
+    msg::AbstractString
+end
+
+function Base.showerror(io::IO, ex::LSRelativePath)
+    print(io, ex.msg)
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -34,6 +34,7 @@ function uri2filepath(uri::AbstractString)
 end
 
 function filepath2uri(file::String)
+    isabspath(file) || throw(LSRelativePath("Relative path `$file` is not valid."))
     if Sys.iswindows()
         file = normpath(file)
         file = replace(file, "\\" => "/")


### PR DESCRIPTION
Helps diagnose #703.

The general idea is that we want to figure out where relative paths come from, and this might help us to narrow that scenario down. My understanding is that we will never receive a URI from a client with a relative path, but that those relative paths originate somewhere in our own code, maybe in the include following logic of StaticLint? Of course, I would just generally remove any loading of non-workspace files from disc :)

CC @pxl-th and @non-Jedi.