### PR TITLE
Fall back to displaying SymbolServer indexing progress on stderr

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -162,6 +162,8 @@ function trigger_symbolstore_reload(server::LanguageServerInstance)
             server.env_path,
             i-> if server.clientcapability_window_workdoneprogress && server.current_symserver_progress_token!==nothing
                 JSONRPCEndpoints.send_notification(server.jr_endpoint, "\$/progress", Dict("token" => server.current_symserver_progress_token, "value" => Dict("kind"=>"report", "message"=>"Indexing $i...")))
+            else
+                @info "Indexing $i..."
             end,
             server.err_handler
         )


### PR DESCRIPTION
Users of fully-capable clients (such as VS code) get a sense of the progress being made by `SymbolServer` while indexing packages. However, clients which don't have the capability to display progress notifications get no information whatsoever. This proposal falls back to simply displaying indexing progress on stderr for such clients.

This helps at least when using the `LanguageServer` within Emacs via `eglot`, which allows to easily display the server output for debugging purposes. I'm not sure whether there are other clients for which such additional output would be unwelcome...