### PR TITLE
don't suggest gensymed names for completions

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -394,7 +394,7 @@ function import_completions(doc, offset, rng, ppt, pt, t, is_at_end ,x, CIs, ser
                 rootmod = StaticLint.getsymbolserver(server)[Symbol(ppt.val)]
                 for (n,m) in rootmod.vals
                     n = String(n)
-                    if startswith(n, t.val)
+                    if startswith(n, t.val) && !startswith(n, "#")
                         push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng, n[length(t.val) + 1:end])))
                     end
                 end
@@ -403,7 +403,7 @@ function import_completions(doc, offset, rng, ppt, pt, t, is_at_end ,x, CIs, ser
             if import_root !== nothing && refof(import_root) isa SymbolServer.ModuleStore
                 for (n,m) in refof(import_root).vals
                     n = String(n)
-                    if startswith(n, t.val)
+                    if startswith(n, t.val) && !startswith(n, "#")
                         push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng, n[length(t.val) + 1:end])))
                     end
                 end

--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -56,8 +56,8 @@ end
 function latex_completions(doc, offset, partial, CIs)
     for (k, v) in REPL.REPLCompletions.latex_symbols
         if startswith(string(k), partial)
-            t1 = TextEdit(Range(doc, offset-sizeof(partial)+1:offset), "") # AUDIT: partial should only contain 1-byte characters as it matches k
-            t2 = TextEdit(Range(doc, offset-sizeof(partial):offset-sizeof(partial)+1), v) # AUDIT: partial should only contain 1-byte characters as it matches k
+            t1 = TextEdit(Range(doc, offset-sizeof(partial)+1:offset), "")
+            t2 = TextEdit(Range(doc, offset-sizeof(partial):offset-sizeof(partial)+1), v)
             push!(CIs, CompletionItem(k[2:end], 11, missing, missing, v, missing, missing, missing, missing, missing, missing, t1, TextEdit[t2], missing, missing, missing))
         end
     end
@@ -166,23 +166,16 @@ end
 function collect_completions(m::SymbolServer.ModuleStore, spartial, rng, CIs, server, inclexported = false, dotcomps = false)
     for val in m.vals
         n, v = String(val[1]), val[2]
-        startswith(n, ".") && continue
-        # v isa String && continue
+        (startswith(n, ".") || startswith(n, "#")) && continue
         !startswith(n, spartial) && continue
         if v isa SymbolServer.VarRef 
             v = SymbolServer._lookup(v, getsymbolserver(server), true)
             v === nothing && return 
         end
         if StaticLint.isexportedby(n, m) || inclexported
-            # if v isa SymbolServer.VarRef
-            #     prv = SymbolServer._lookup(getsymbolserver(server), v)
-            #     !(prv isa SymbolServer.SymStore) && continue
-            #     push!(CIs, CompletionItem(n, _completion_kind(prv, server), MarkupContent(sanitize_docstring(prv.doc)), TextEdit(rng, n[nextind(n,sizeof(spartial)):end])))
-            # else
-                push!(CIs, CompletionItem(n, _completion_kind(v, server), MarkupContent(sanitize_docstring(v.doc)), TextEdit(rng, n[nextind(n,sizeof(spartial)):end]))) # AUDIT: nextind(n,sizeof(n)) equiv to nextind(n, lastindex(n))
-            # end
+            push!(CIs, CompletionItem(n, _completion_kind(v, server), MarkupContent(sanitize_docstring(v.doc)), TextEdit(rng, n[nextind(n,sizeof(spartial)):end])))
         elseif dotcomps
-            rng1 = Range(Position(rng.start.line, rng.start.character - sizeof(spartial)), rng.stop) # AUDIT: PROBLEM?: combining utf16 character offset with byte offset, no current impact 
+            rng1 = Range(Position(rng.start.line, rng.start.character - sizeof(spartial)), rng.stop)
             push!(CIs, CompletionItem(n, _completion_kind(v, server), MarkupContent(sanitize_docstring(v.doc)), TextEdit(rng1, string(m.name, ".", n)))) 
         end
     end
@@ -213,7 +206,7 @@ function collect_completions(x::StaticLint.Scope, spartial, rng, CIs, server, in
                     documentation = get_hover(n[2], documentation, server)
                     sanitize_docstring(documentation)
                 end
-                push!(CIs, CompletionItem(n[1], _completion_kind(n[2], server), MarkupContent(documentation), TextEdit(rng, n[1][nextind(n[1],sizeof(spartial)):end]))) # AUDIT: nextind(n,sizeof(n)) equiv to nextind(n, lastindex(n))
+                push!(CIs, CompletionItem(n[1], _completion_kind(n[2], server), MarkupContent(documentation), TextEdit(rng, n[1][nextind(n[1],sizeof(spartial)):end])))
             end
         end
     end
@@ -241,14 +234,14 @@ function _get_dot_completion(px::EXPR, spartial, rng, CIs, server)
                 for a in refof(px).type.fieldnames
                     a = String(a)
                     if startswith(a, spartial)
-                        push!(CIs, CompletionItem(a, 2, MarkupContent(a), TextEdit(rng, a[nextind(a,sizeof(spartial)):end]))) # AUDIT: nextind(n,sizeof(n)) equiv to nextind(n, lastindex(n))
+                        push!(CIs, CompletionItem(a, 2, MarkupContent(a), TextEdit(rng, a[nextind(a,sizeof(spartial)):end])))
                     end
                 end
             elseif refof(px).type isa StaticLint.Binding && refof(px).type.val isa SymbolServer.DataTypeStore
                 for a in refof(px).type.val.fieldnames
                     a = String(a)
                     if startswith(a, spartial)
-                        push!(CIs, CompletionItem(a, 2, MarkupContent(a), TextEdit(rng, a[nextind(a,sizeof(spartial)):end]))) # AUDIT: nextind(n,sizeof(n)) equiv to nextind(n, lastindex(n))
+                        push!(CIs, CompletionItem(a, 2, MarkupContent(a), TextEdit(rng, a[nextind(a,sizeof(spartial)):end])))
                     end
                 end
             elseif refof(px).type isa StaticLint.Binding && refof(px).type.val isa EXPR && CSTParser.defines_struct(refof(px).type.val) && scopeof(refof(px).type.val) isa StaticLint.Scope
@@ -378,14 +371,14 @@ function import_completions(doc, offset, rng, ppt, pt, t, is_at_end ,x, CIs, ser
         if import_root !== nothing && refof(import_root) isa SymbolServer.ModuleStore
             for (n,m) in refof(import_root).vals
                 n = String(n)
-                if startswith(n, t.val)
+                if startswith(n, t.val) && !startswith(n, "#")
                     push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng, n[length(t.val) + 1:end])))
                 end
             end
         else
             for (n,m) in StaticLint.getsymbolserver(server)
                 n = String(n)
-                startswith(n, ".") && continue
+                (startswith(n, ".") || startswith(n, "#")) && continue
                 push!(CIs, CompletionItem(n, 9, MarkupContent(sanitize_docstring(m.doc)), TextEdit(rng, n)))
             end
         end
@@ -418,7 +411,7 @@ function import_completions(doc, offset, rng, ppt, pt, t, is_at_end ,x, CIs, ser
                 for (n,m) in StaticLint.getsymbolserver(server)
                     n = String(n)
                     if startswith(n, t.val)
-                        push!(CIs, CompletionItem(n, 9, MarkupContent(m isa SymbolServer.SymStore ? m.doc : n), TextEdit(rng, n[nextind(n,sizeof(t.val)):end]))) # AUDIT: nextind(n,sizeof(n)) equiv to nextind(n, lastindex(n))
+                        push!(CIs, CompletionItem(n, 9, MarkupContent(m isa SymbolServer.SymStore ? m.doc : n), TextEdit(rng, n[nextind(n,sizeof(t.val)):end])))
                     end
                 end
             end


### PR DESCRIPTION
This should prevent gensymed variables being suggested for completions. This reminds me that completions don't works with the `var"someid"` syntax but that's not an immediate priority

closes #719 