### PR TITLE
possible workaround for clients that incorrectly pass null values

### DIFF
--- a/src/protocol/protocol.jl
+++ b/src/protocol/protocol.jl
@@ -43,7 +43,11 @@ macro dict_readable(arg)
             if fieldtype isa Expr && fieldtype.head == :curly && fieldtype.args[2] != :Any
                 f = :($(fieldtype.args[2]).(dict[$fieldname]))
             elseif fieldtype != :Any
-                f = :($(fieldtype)(dict[$fieldname]))
+                f = if field_allows_missing(field)
+                    :($fieldtype(dict[$fieldname] isa Nothing ? missing : dict[$fieldname]))
+                else
+                    :($fieldtype(dict[$fieldname]))
+                end
             else
                 f = :(dict[$fieldname])
             end


### PR DESCRIPTION
This is a possible workaround for #730 .

Please only feel compelled to merge this if you really think it's appropriate, and not just because you hope it'll get things working, because it won't.  Even with this issue resolved all sorts of (seemingly unrelated) things are going wrong when trying to use this with neovim, so this absolutely does not get it working, and this has been quite an exercise in frustration.