### PR TITLE
Refactor -> anonymous function

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -170,7 +170,7 @@ function trigger_symbolstore_reload(server::LanguageServerInstance)
         ssi_ret, payload = SymbolServer.getstore(
             server.symbol_server,
             server.env_path,
-            function(i)
+            function (i)
                 if server.clientcapability_window_workdoneprogress && server.current_symserver_progress_token !== nothing
                     JSONRPC.send(
                         server.jr_endpoint,

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -170,15 +170,17 @@ function trigger_symbolstore_reload(server::LanguageServerInstance)
         ssi_ret, payload = SymbolServer.getstore(
             server.symbol_server,
             server.env_path,
-            i->if server.clientcapability_window_workdoneprogress && server.current_symserver_progress_token !== nothing
-            JSONRPC.send(
-                    server.jr_endpoint,
-                    progress_notification_type,
-                    ProgressParams(server.current_symserver_progress_token, WorkDoneProgressReport(missing, "Indexing $i...", missing))
-                )
-        else
-            @info "Indexing $i..."
-        end,
+            function(i)
+                if server.clientcapability_window_workdoneprogress && server.current_symserver_progress_token !== nothing
+                    JSONRPC.send(
+                        server.jr_endpoint,
+                        progress_notification_type,
+                        ProgressParams(server.current_symserver_progress_token, WorkDoneProgressReport(missing, "Indexing $i...", missing))
+                    )
+                else
+                    @info "Indexing $i..."
+                end
+            end,
             server.err_handler
         )
 


### PR DESCRIPTION
Using the `function(x)` syntax makes this callback clearer and doesn't
confuse indentation so much.