### PR TITLE
Provide default values for configurations

### DIFF
--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -111,9 +111,9 @@ function request_julia_config(server::LanguageServerInstance, conn)
         new_runlinter = isnothing(response[23]) ? false : true
         new_SL_opts = StaticLint.LintOptions([isnothing(a) ? (StaticLint.default_options[i] isa Bool ? false : StaticLint.default_options[i]) : a for (i, a) in enumerate(response[13:22])]...)
     else
-        server.format_options = DocumentFormat.FormatOptions(response[1:12]...)
+        server.format_options = DocumentFormat.FormatOptions([something(a, DocumentFormat.default_options[i]) for (i, a) in enumerate(response[1:12])]...)
         new_runlinter = something(response[23], true)
-        new_SL_opts = StaticLint.LintOptions(response[13:22]...)
+        new_SL_opts = StaticLint.LintOptions([something(a, StaticLint.default_options[i]) for (i, a) in enumerate(response[13:22])]...)
     end
     new_lint_missingrefs = Symbol(something(response[24], :all))
 


### PR DESCRIPTION
The server crashes since v3.1.0 if the client doesn't provide a configuration setting (i.e. sends `null`) for the workspace/configuration request. In that case the server should use a default value instead.

VS Code was not affected, because it gets special handling in [workspace.jl#L109](https://github.com/julia-vscode/LanguageServer.jl/blob/922bd32fe9e19423b926f166ac39b40e7b5720b1/src/requests/workspace.jl#L109).

By the way `"julia.format.kwspacing"` doesn't match what is used in [DocumentFormat](https://github.com/julia-vscode/DocumentFormat.jl/blob/598cf38943161319e976f8ba4296f49be3c55e00/src/DocumentFormat.jl#L22) and [vscode](https://github.com/julia-vscode/julia-vscode/blob/77db2a3b4c14a64bbbe2e858c5a192129868748a/package.json#L577).