### PR TITLE
alter getCurrentBlockRange request

### DIFF
--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -5,47 +5,49 @@ end
 function setTraceNotification_notification(params, server::LanguageServerInstance, conn)
 end
 
-function julia_getCurrentBlockRange_request(params::TextDocumentPositionParams, server::LanguageServerInstance, conn)
-    tdpp = params
+function julia_getCurrentBlockRange_request(tdpp::TextDocumentPositionParams, server::LanguageServerInstance, conn)
     doc = getdocument(server, URI2(tdpp.textDocument.uri))
     offset = get_offset(doc, tdpp.position)
     x = getcst(doc)
     loc = 0
-    p1, p2, p3 = 0, x.span, x.fullspan
+
     if typof(x) === CSTParser.FileH
-        (offset > x.fullspan || x.args === nothing) && return Position(get_position_at(doc, p1)...), Position(get_position_at(doc, p2)...), Position(get_position_at(doc, p3)...)
         for a in x.args
-            if loc <= offset < loc + a.fullspan
-                if typof(a) === CSTParser.ModuleH
-                    if loc + a.args[1].fullspan + a.args[2].fullspan < offset < loc + a.args[1].fullspan + a.args[2].fullspan + a.args[3].fullspan
-                        loc0 = loc +  a.args[1].fullspan + a.args[2].fullspan
+            if loc <= offset <= loc + a.span
+                if CSTParser.defines_module(a) # Within module at the top-level, lets see if we can select on of the block arguments
+                    if loc <= offset <= loc + a.args[1].span # Within `module` keyword, so return entire expression
+                        return Position(get_position_at(doc, loc)...), Position(get_position_at(doc, loc + a.span)...), Position(get_position_at(doc, loc + a.fullspan)...)
+                    end
+                    if loc + a.args[1].fullspan <= offset <= loc + a.args[1].fullspan + a.args[2].span # Within name of the module, so return entire expression
+                        return Position(get_position_at(doc, loc)...), Position(get_position_at(doc, loc + a.span)...), Position(get_position_at(doc, loc + a.fullspan)...)
+                    end
+
+                    if loc + a.args[1].fullspan + a.args[2].fullspan <= offset <= loc + a.args[1].fullspan + a.args[2].fullspan + a.args[3].span # Within the body of a module
                         loc += a.args[1].fullspan + a.args[2].fullspan
                         for b in a.args[3].args
-                            if loc <= offset < loc + b.fullspan
-                                p1, p2, p3 = loc, loc + b.span, loc + b.fullspan
-                                break
+                            if loc <= offset <= loc + b.span
+                                return Position(get_position_at(doc, loc)...), Position(get_position_at(doc, loc + b.span)...), Position(get_position_at(doc, loc + b.fullspan)...)
                             end
                             loc += b.fullspan
                         end
-                    else
-                        p1, p2, p3 = loc, loc + a.span, loc + a.fullspan
+                    elseif loc + a.args[1].fullspan + a.args[2].fullspan + a.args[3].fullspan < offset < loc + a.args[1].fullspan + a.args[2].fullspan + a.args[3].fullspan + a.args[4].span # Within `end` of the module, so return entire expression
+                        return Position(get_position_at(doc, loc)...), Position(get_position_at(doc, loc + a.span)...), Position(get_position_at(doc, loc + a.fullspan)...)
                     end
                 elseif typof(a) === CSTParser.TopLevel
-                    p1, p2, p3 = loc, loc + a.span, loc + a.fullspan
                     for b in a.args
-                        if loc <= offset < loc + b.fullspan
-                            p1, p2, p3 = loc, loc + b.span, loc + b.fullspan
+                        if loc <= offset <= loc + b.span
+                            return Position(get_position_at(doc, loc)...), Position(get_position_at(doc, loc + b.span)...), Position(get_position_at(doc, loc + b.fullspan)...)
                         end
                         loc += b.fullspan
                     end
                 else
-                    p1, p2, p3 = loc, loc + a.span, loc + a.fullspan
+                    return Position(get_position_at(doc, loc)...), Position(get_position_at(doc, loc + a.span)...), Position(get_position_at(doc, loc + a.fullspan)...)
                 end
             end
             loc += a.fullspan
         end
     end
-    return Position(get_position_at(doc, p1)...), Position(get_position_at(doc, p2)...), Position(get_position_at(doc, p3)...)
+    return Position(0, 0), Position(0, 0), tdpp.position
 end
 
 function julia_activateenvironment_notification(params::String, server::LanguageServerInstance, conn)


### PR DESCRIPTION
fixes #716 ?

Changes the behaviour to ignore trailing white space when considering which block to retrieve. By default returns an empty selection at (0,0):(0,0). @pfitzseb , is this what was wanted? 