### PR TITLE
nothing -> missing in WorkspaceEdit

### DIFF
--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -115,7 +115,7 @@ function explicitly_import_used_variables(x::EXPR, server, conn)
         return
     end
 
-    JSONRPC.send(conn, workspace_applyEdit_request_type, ApplyWorkspaceEditParams(missing, WorkspaceEdit(nothing, collect(values(tdes)))))
+    JSONRPC.send(conn, workspace_applyEdit_request_type, ApplyWorkspaceEditParams(missing, WorkspaceEdit(missing, collect(values(tdes)))))
 end
 
 is_single_line_func(x) = CSTParser.defines_function(x) && typof(x) !== CSTParser.FunctionDef

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -204,7 +204,7 @@ function textDocument_rename_request(params::RenameParams, server::LanguageServe
         end
     end
 
-    return WorkspaceEdit(nothing, collect(values(tdes)))
+    return WorkspaceEdit(missing, collect(values(tdes)))
 end
 
 


### PR DESCRIPTION
closes #763

This is because `WorkspaceEdit` is mis-specified within our version of the spec, what does: 
`ts { [uri: DocumentUri]: TextEdit[]; };` mean? 

Is it a vector of pairs `(DocumentUri, Vector{TextEdit})`?