### PR TITLE
fix use of StaticLint.iterate_over_ss_methods

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -117,6 +117,7 @@ function get_definitions(x::T, tls, server, locations, visited = nothing) where 
         catch err
             isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
         end
+        return false
     end)
 end
 


### PR DESCRIPTION
This should be merged urgently, sorry all.