### PR TITLE
Fix a race condition for progress tokens

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -137,13 +137,14 @@ end
 
 function create_symserver_progress_ui(server)
     if server.clientcapability_window_workdoneprogress
-        server.current_symserver_progress_token = string(uuid4())
-        response = JSONRPC.send(server.jr_endpoint, window_workDoneProgress_create_request_type, WorkDoneProgressCreateParams(server.current_symserver_progress_token))
+        token = string(uuid4())
+        server.current_symserver_progress_token = token
+        response = JSONRPC.send(server.jr_endpoint, window_workDoneProgress_create_request_type, WorkDoneProgressCreateParams(token))
 
         JSONRPC.send(
             server.jr_endpoint,
             progress_notification_type,
-            ProgressParams(server.current_symserver_progress_token, WorkDoneProgressBegin("Julia Language Server", missing, "Indexing packages...", missing))
+            ProgressParams(token, WorkDoneProgressBegin("Julia Language Server", missing, "Indexing packages...", missing))
         )
     end
 end


### PR DESCRIPTION
Fixes a race condition that came in via crash reporting.

The problem is that during the `JSONRPC.send` call other tasks can set `server.current_symserver_progress_token` to `nothing`, and then we crash. Here we use a local variable now to for `send` calls, which ensures that we can't get into that state.