### PR TITLE
Fix tests

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -28,7 +28,7 @@ For normal usage, the language server can be instantiated with
   path. The path must exist on disc before this is called.
 """
 mutable struct LanguageServerInstance
-    jr_endpoint::JSONRPC.JSONRPCEndpoint
+    jr_endpoint::Union{JSONRPC.JSONRPCEndpoint,Nothing}
     workspaceFolders::Set{String}
     _documents::Dict{URI2,Document}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,11 @@
 using Test, Sockets, LanguageServer, CSTParser, SymbolServer, SymbolServer.Pkg, StaticLint, JSON
 using LanguageServer: Document, get_text, get_offset, get_line_offsets, get_position_at, get_open_in_editor, set_open_in_editor, is_workspace_file, applytextdocumentchanges
+import JSONRPC
 const LS = LanguageServer
 const Range = LanguageServer.Range
+
+# TODO Replace this with a proper mock endpoint
+JSONRPC.send(::Nothing, ::Any, ::Any) = nothing
 
 @testset "LanguageServer" begin
 

--- a/test/test_actions.jl
+++ b/test/test_actions.jl
@@ -1,5 +1,6 @@
 server = LanguageServerInstance(IOBuffer(), IOBuffer(), dirname(Pkg.Types.Context().env.project_file), first(Base.DEPOT_PATH))
 server.runlinter = true
+server.jr_endpoint = nothing
 
 LanguageServer.initialize_request(init_request, server, nothing)
 

--- a/test/test_edit.jl
+++ b/test/test_edit.jl
@@ -9,6 +9,7 @@ mktempdir() do dir
     init_params = LanguageServer.InitializeParams(JSON.parse(initstr))
 
     server.runlinter = true
+    server.jr_endpoint = nothing
     LanguageServer.initialize_request(init_params, server, nothing)
     # LanguageServer.process(LanguageServer.JSONRPC.Request{Val{Symbol("initialized")},Any}(0, nothing), server)
 

--- a/test/test_intellisense.jl
+++ b/test/test_intellisense.jl
@@ -1,5 +1,6 @@
 server = LanguageServerInstance(IOBuffer(), IOBuffer(), dirname(Pkg.Types.Context().env.project_file), first(Base.DEPOT_PATH))
 server.runlinter = true
+server.jr_endpoint = nothing
 
 LanguageServer.initialize_request(init_request, server, nothing)
 


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/797.

This is the minimal fix I came up with for the CI testing. Unfortunately it does require one change to the package code just to fix the tests, but I couldn't come up with a better idea.

The problem here is that for the LS tests we don't set up a full communication channel, and so we need a way to make sure things like sending diagnostics don't error. My plan had be to enable a full mocking story, but I never finished this, so this is a somewhat lame emulation of that: if the endpoint is `nothing`, in the test case we make sending a notification to such a nothing endpoint a no op. I know how to improve this generally, but that would require more refactoring of the code that ships to users, so I think that should probably wait until after Juliacon, and for now we go with this minimal fix to get back our CI testing.

The reason this slipped into `master` in the first place was that a JSONRPC.jl update exposed a bug in the LS tests.