### PR TITLE
Escape from get_func_hover loop

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -1,6 +1,6 @@
 function get_signatures(b, tls, sigs, server, visited = nothing) end # Fallback
 
-function get_signatures(b::StaticLint.Binding, tls::StaticLint.Scope, sigs::Vector{SignatureInformation}, server, visited = Base.IdSet{StaticLint.Binding}())
+function get_signatures(b::StaticLint.Binding, tls::StaticLint.Scope, sigs::Vector{SignatureInformation}, server, visited = StaticLint.Binding[])
     if b in visited                                      # TODO: remove
         throw(LSInfiniteLoop("Possible infinite loop.")) # TODO: remove
     else                                                 # TODO: remove
@@ -93,7 +93,7 @@ end
 
 # TODO: should be in StaticLint. visited check is costly.
 resolve_shadow_binding(b) = b
-function resolve_shadow_binding(b::StaticLint.Binding, visited = Base.IdSet{StaticLint.Binding}())
+function resolve_shadow_binding(b::StaticLint.Binding, visited = StaticLint.Binding[])
     if b in visited
         throw(LSInfiniteLoop("Inifinite loop in bindings."))
     else
@@ -121,7 +121,7 @@ function get_definitions(x::T, tls, server, locations, visited = nothing) where 
     end)
 end
 
-function get_definitions(b::StaticLint.Binding, tls, server, locations, visited = Base.IdSet{StaticLint.Binding}())
+function get_definitions(b::StaticLint.Binding, tls, server, locations, visited = StaticLint.Binding[])
     if b in visited                                      # TODO: remove
         throw(LSInfiniteLoop("Possible infinite loop.")) # TODO: remove
     else                                                 # TODO: remove

--- a/src/requests/hover.jl
+++ b/src/requests/hover.jl
@@ -96,9 +96,11 @@ end
 get_func_hover(x, documentation, server, visited = nothing) = documentation
 get_func_hover(x::SymbolServer.SymStore, documentation, server, visited = nothing) = get_hover(x, documentation, server)
 
-function get_func_hover(b::StaticLint.Binding, documentation, server, visited = Base.IdSet{StaticLint.Binding}())
+function get_func_hover(b::StaticLint.Binding, documentation, server, visited = StaticLint.Binding[])
     if b in visited                                      # TODO: remove
-        throw(LSInfiniteLoop("Possible infinite loop.")) # TODO: remove
+        # throw(LSInfiniteLoop("Possible infinite loop.")) # TODO: remove
+        # There is a cycle in the links between Bindings. Root cause is in StaticLint but there is no reason to allow it to crash the language server. If we have done a complete circuit here then we have all the information we need and can return.
+        return documentation
     else                                                 # TODO: remove
         push!(visited, b)                                # TODO: remove
     end                                                  # TODO: remove
@@ -148,7 +150,7 @@ end
 
 get_fcall_position(x, documentation, visited = nothing) = documentation
 
-function get_fcall_position(x::EXPR, documentation, visited = Base.IdSet{EXPR}())
+function get_fcall_position(x::EXPR, documentation, visited = EXPR[])
     if xor in visited                                      # TODO: remove
         throw(LSInfiniteLoop("Possible infinite loop.")) # TODO: remove
     else                                                 # TODO: remove


### PR DESCRIPTION
There is a cycle in the links (`.prev`/`.next`) between StaticLint.Bindings. The root cause is within StaticLint but there is no reason to allow it to crash the language server. If we have done a complete circuit here (i.e. a loop is detected) then we have all the information we need and can `return`.

As this is being hit quite a lot, this approach seems best for the user while the StaticLint bug is fixed. Thoughts?