### PR TITLE
Fix an offset bug

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -349,7 +349,7 @@ function julia_getModuleAt_request(params::VersionedTextDocumentPositionParams, 
     if hasdocument(server, uri)
         doc = getdocument(server, uri)
         if doc._version == params.version
-            offset = get_offset(doc, params.position)
+            offset = get_offset2(doc, params.position.line, params.position.character)
             x = get_expr(getcst(doc), offset)
             if x isa EXPR
                 scope = StaticLint.retrieve_scope(x)


### PR DESCRIPTION
Next attempt to fix https://github.com/julia-vscode/LanguageServer.jl/issues/768.

This is kind of embarrassing because I completely forgot about the whole `offset` vs `offset2` thing in the code base... Here is the background story: we had a lot of text sync errors in the fall, so I rewrote the whole text sync logic, largely just copying the algorithm from the original MS node implementation. One thing I was never able to square was the original `get_offset` implementation we had and one that followed the MS logic (that is to say, I didn't really understand our implementation :) ). In the end I added the MS based implementation as `get_offset2` and used that for all the text sync stuff. That got rid of all the text sync bugs. I didn't remove the original `get_offset` implementation because I didn't fully understand the ways it was used in various other parts of the LS, and was worried that my new implementation actually used a slightly different definition than our original implementation. So, I left it in there and some of the request handlers still use it today.

So one simple explanation for our problems here is that the old `get_offset` implementation might just be buggy. The fact that swapping it out for the text sync stuff fixed all the problems around that suggests so :) I don't really know why I never followed up on this and tried to generally use `get_offset2` everywhere in the code base, I think I simply forgot...

So this just swaps things out and uses the `get_offset2` implementation here. Maybe that will just fix things :)