### PR TITLE
add another nothing check to initialize_request

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -130,7 +130,9 @@ function initialize_request(params::InitializeParams, server::LanguageServerInst
         end
     elseif (params.workspaceFolders !== nothing) & (params.workspaceFolders !== missing)
         for wksp in params.workspaceFolders
-            push!(server.workspaceFolders, uri2filepath(wksp.uri))
+            if wksp.uri !== nothing
+                push!(server.workspaceFolders, uri2filepath(wksp.uri))
+            end
         end
     end
 


### PR DESCRIPTION
Fixes a bug that showed up on azure:

```
MethodError: Cannot `convert` an object of type Nothing to an object of type String
Closest candidates are:
  convert(::Type{String}, !Matched::FilePathsBase.AbstractPath) at /Users/.../.vscode/extensions/julialang.language-julia-0.17.8/scripts/packages/FilePathsBase/src/path.jl:107
  convert(::Type{T}, !Matched::T) where T<:AbstractString at strings/basic.jl:209
  convert(::Type{T}, !Matched::AbstractString) where T<:AbstractString at strings/basic.jl:210
   at setindex!(::Dict{String,Nothing}, ::Nothing, ::Nothing) (dict.jl372)
   at push!(::Set{String}, ::Nothing) (set.jl48)
   at initialize_request(::LanguageServer.InitializeParams, ::LanguageServerInstance, ::JSONRPC.JSONRPCEndpoint) (./julialang.language-julia-0.17.8/scripts/packages/LanguageServer/src/requests/init.jl133)
   at (::LanguageServer.var"#111#143"{LanguageServerInstance})(::JSONRPC.JSONRPCEndpoint, ::LanguageServer.InitializeParams) (./julialang.language-julia-0.17.8/scripts/packages/LanguageServer/src/languageserverinstance.jl284)
   at dispatch_msg(::JSONRPC.JSONRPCEndpoint, ::JSONRPC.MsgDispatcher, ::Dict{String,Any}) (./julialang.language-julia-0.17.8/scripts/packages/JSONRPC/src/typed.jl66)
   at run(::LanguageServerInstance) (./julialang.language-julia-0.17.8/scripts/packages/LanguageServer/src/languageserverinstance.jl309)
   at top-level scope (./julialang.language-julia-0.17.8/scripts/languageserver/main.jl59)
   at include(::Module, ::String) (Base.jl377)
   at exec_options(::Base.JLOptions) (client.jl288)
   at _start() (client.jl484)
```
