### PR TITLE
feat: get_project_language_server

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "2b0e0bc5-e4fd-59b4-8912-456d1b03d8d7"
 version = "3.2.1-DEV"
 
 [deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -16,7 +17,6 @@ SymbolServer = "cf896787-08d5-524d-9de7-132aaa0cb996"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 
 [extras]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -327,3 +327,32 @@ function Base.run(server::LanguageServerInstance)
         end
     end
 end
+
+using Pkg
+
+VersionFloat(v::VersionNumber) = join(split(string(v),'.')[1:2],'.')
+
+global_env_path = joinpath(homedir(),".julia/environments/v$(VersionFloat(VERSION))")
+
+"""
+    get_project_language_server()
+
+Get a language server instance for current julia session using the default options. If the path of current project uses the global environment path, it will activate the project to speed up the process.
+"""
+function get_project_language_server()
+
+    current_project = Pkg.project()
+    current_env_path = dirname(current_project.path)
+
+    # Force activation to speed up the process
+    if current_env_path == global_env_path
+        @warn("Activating the project at $(pwd())")
+        Pkg.activate(".")
+        current_project = Pkg.project()
+        current_env_path = dirname(current_project.path)
+    end
+
+    env_path = current_env_path
+
+    return LanguageServerInstance(stdin, stdout, env_path)
+end


### PR DESCRIPTION
Adds a function to get the project's language server

Analogous to https://github.com/julia-vscode/SymbolServer.jl/pull/190

# TODO 
Add tests