### PR TITLE
include link to new Kakoune wiki entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ make use of the Julia Language Server for various code editing features:
 - [Vim and Neovim](../../wiki/Vim-and-Neovim)
 - [Emacs](../../wiki/Emacs)
 - [Sublime Text](https://github.com/tomv564/LSP)
+- [Kakoune](../../wiki/Kakoune)
 
 ## Installation and Usage
 **Documentation**: [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://www.julia-vscode.org/LanguageServer.jl/dev)


### PR DESCRIPTION
I've added a Wiki entry which describes a kakoune setup with julia lsp integration. This PR aims to link the new entry in the `README.md`