### PR TITLE
throw source with errs

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -227,7 +227,16 @@ function parse_all(doc::Document, server::LanguageServerInstance)
     if endswith(doc._uri, ".jmd")
         doc.cst, ps = parse_jmd(ps, get_text(doc))
     else
-        doc.cst, ps = CSTParser.parse(ps, true)
+        try
+            doc.cst, ps = CSTParser.parse(ps, true)
+        catch err
+            # This throws users' source text to error...
+            if err isa CSTInfiniteLoop
+                error("CSTParser looped while parsing: \"$(get_text(doc))\" ")
+            else
+                err
+            end
+        end
     end
     if typof(doc.cst) === CSTParser.FileH
         doc.cst.val = getpath(doc)


### PR DESCRIPTION
Throws the source file contents that we're trying to parse when we hit a CSTInfiniteLoop. Can't get to the bottom of the loops without this, I don't think. A discussion is needed as to whether this is acceptable (beyond expectations of what users diagnostics send to us should include). 