### PR TITLE
ensure parent doc is set

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -326,6 +326,7 @@ function relintserver(server)
     documents = getdocuments_value(server)
     for doc in documents
         StaticLint.clear_meta(getcst(doc))
+        set_doc(getcst(doc), doc)
     end
     for doc in documents
         # only do a pass on documents once


### PR DESCRIPTION
the `meta.error` field for a Document's `EXPR` points to the doc itself (this allows us to get the file/line location from an isolated `EXPR`). It was being removed, breaking things (e.g. refs, definitions, etc)