### PR TITLE
only provide toplevel symbols in tS/dS in vim

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -177,8 +177,11 @@ function textDocument_documentSymbol_request(params::DocumentSymbolParams, serve
     syms = SymbolInformation[]
     uri = params.textDocument.uri
     doc = getdocument(server, URI2(uri))
-
-    bs = collect_bindings_w_loc(getcst(doc))
+    if client_type(server) == :vim
+        bs = collect_toplevel_bindings_w_loc(getcst(doc))
+    else
+        bs = collect_bindings_w_loc(getcst(doc))
+    end
     for x in bs
         p, b = x[1], x[2]
         !(b.val isa EXPR) && continue

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -109,14 +109,14 @@ function request_julia_config(server::LanguageServerInstance, conn)
         ConfigurationItem(missing, "julia.lint.disabledDirs")
         ]))
 
-    if server.clientInfo isa InfoParams && (server.clientInfo.name == "Visual Studio Code" || server.clientInfo.name == "Visual Studio Code - Insiders")
-        server.format_options = DocumentFormat.FormatOptions([isnothing(a) ? (DocumentFormat.default_options[i] isa Bool ? false : DocumentFormat.default_options[i]) : a for (i, a) in enumerate(response[1:12])]...)
-        new_runlinter = isnothing(response[23]) ? false : true
-        new_SL_opts = StaticLint.LintOptions([isnothing(a) ? (StaticLint.default_options[i] isa Bool ? false : StaticLint.default_options[i]) : a for (i, a) in enumerate(response[13:22])]...)
-    else
+    if client_type(server) == :vim
         server.format_options = DocumentFormat.FormatOptions(response[1:12]...)
         new_runlinter = something(response[23], true)
         new_SL_opts = StaticLint.LintOptions(response[13:22]...)
+    else
+        server.format_options = DocumentFormat.FormatOptions([isnothing(a) ? (DocumentFormat.default_options[i] isa Bool ? false : DocumentFormat.default_options[i]) : a for (i, a) in enumerate(response[1:12])]...)
+        new_runlinter = isnothing(response[23]) ? false : true
+        new_SL_opts = StaticLint.LintOptions([isnothing(a) ? (StaticLint.default_options[i] isa Bool ? false : StaticLint.default_options[i]) : a for (i, a) in enumerate(response[13:22])]...)
     end
     new_lint_missingrefs = Symbol(something(response[24], :all))
     new_lint_disableddirs = something(response[25], LINT_DIABLED_DIRS)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -441,3 +441,11 @@ function is_in_target_dir_of_package(pkgpath, target)
     end
 end
 
+function client_type(server::LanguageServerInstance)
+    if server.clientInfo isa InfoParams
+        if occursin(r"vim", server.clientInfo.name)
+            :vim
+        end
+    end
+    :vscode
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -444,8 +444,10 @@ end
 function client_type(server::LanguageServerInstance)
     if server.clientInfo isa InfoParams
         if occursin(r"vim", server.clientInfo.name)
-            :vim
+            return :vim
+        elseif (server.clientInfo.name == "Visual Studio Code" || server.clientInfo.name == "Visual Studio Code - Insiders")
+            return :vscode
         end
     end
-    :vscode
+    return :unknown
 end


### PR DESCRIPTION
Fixes #681 for now. It's useful to give vscode all the symbols at it automatically nests them within the relevant blocks

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
