### PR TITLE
special handling for CompletionContext

### DIFF
--- a/src/protocol/completion.jl
+++ b/src/protocol/completion.jl
@@ -74,9 +74,13 @@ struct CompletionRegistrationOptions <: Outbound
     resolveProvider::Union{Bool,Missing}
 end
 
-@dict_readable struct CompletionContext <: Outbound
+struct CompletionContext <: Outbound
     triggerKind::CompletionTriggerKind
     triggerCharacter::Union{String,Missing}
+end
+
+function CompletionContext(d::Dict)
+    CompletionContext(d["triggerKind"], haskey(d, "triggerCharacter") && d["triggerCharacter"] isa String ? d["triggerCharacter"] : missing)
 end
 
 @dict_readable struct CompletionParams <: Outbound


### PR DESCRIPTION
Allow for `nothing` in CompletionContext.triggerCharacter
