### PR TITLE
improve walkdir err handling

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -119,8 +119,11 @@ function load_folder(path::String, server)
     end
 end
 
-function is_walkdir_error(err)
-    return isa(err, Base.IOError) || isa(err, Base.SystemError) || (VERSION > v"1.3.0-" && isa(err, Base.TaskFailedException))
+is_walkdir_error(_) = false
+is_walkdir_error(::Base.IOError) = true
+is_walkdir_error(::Base.SystemError) = true
+@static if VERSION > v"1.3.0-"
+    is_walkdir_error(err::Base.TaskFailedException) = is_walkdir_error(err.task.exception)
 end
 
 function initialize_request(params::InitializeParams, server::LanguageServerInstance, conn)

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -76,7 +76,7 @@ function load_rootpath(path)
             !isjuliabasedir(path) &&
             !has_too_many_files(path)
     catch err
-        isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
+        is_walkdir_error(err) || rethrow()
         return false
     end
 end
@@ -103,7 +103,7 @@ function load_folder(path::String, server)
                                 isvalid(s) || continue
                                 s
                             catch err
-                                isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
+                                is_walkdir_error(err) || rethrow()
                                 continue
                             end
                             doc = Document(uri, content, true, server)
@@ -114,11 +114,14 @@ function load_folder(path::String, server)
                 end
             end
         catch err
-            isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
+            is_walkdir_error(err) || rethrow()
         end
     end
 end
 
+function is_walkdir_error(err)
+    return isa(err, Base.IOError) || isa(err, Base.SystemError) || (VERSION > v"1.3.0-" && isa(err, Base.TaskFailedException))
+end
 
 function initialize_request(params::InitializeParams, server::LanguageServerInstance, conn)
     # Only look at rootUri and rootPath if the client doesn't support workspaceFolders


### PR DESCRIPTION
Fixes an error we got on [Azure](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%226803c4ed-bcb4-41d4-bceb-7faf5e7a3469%22%2C%22ResourceGroup%22%3A%22Default%22%2C%22Name%22%3A%22julia-vscode%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%2Fsubscriptions%2F6803c4ed-bcb4-41d4-bceb-7faf5e7a3469%2FresourceGroups%2FDefault%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fjulia-vscode%22%2C%22ResourceType%22%3A%22microsoft.insights%2Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%2298a89171-6c36-11eb-964c-77d7a7635906%22%2C%22timestamp%22%3A%222021-02-11T06%3A58%3A49.745Z%22%2C%22cacheId%22%3A%22d77d3cf7-d333-4d76-98c7-a6ad5fba5078%22%2C%22eventTable%22%3A%22exceptions%22%7D9).

~Ideally we'd unwrap the `TaskFailedException` and check the type of the contained error, but I'm not sure how to do that (`err.task.exception.task.exception` doesn't seem particularly robust).~

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
