### PR TITLE
Add a diagnostic for relative paths

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -13,7 +13,7 @@ mutable struct Document
     root::Document
     function Document(uri::AbstractString, text::AbstractString, workspace_file::Bool, server=nothing)
         path = something(uri2filepath(uri), "")
-        isabspath(path) || throw(LSRelativePath("Relative path `$path` is not valid."))
+        path == "" || isabspath(path) || throw(LSRelativePath("Relative path `$path` is not valid."))
         cst = CSTParser.parse(text, true)
         doc = new(uri, path, text, nothing, nothing, false, workspace_file, cst, [], 0, server)
         get_line_offsets(doc)

--- a/src/document.jl
+++ b/src/document.jl
@@ -13,6 +13,7 @@ mutable struct Document
     root::Document
     function Document(uri::AbstractString, text::AbstractString, workspace_file::Bool, server=nothing)
         path = something(uri2filepath(uri), "")
+        isabspath(path) || throw(LSRelativePath("Relative path `$path` is not valid."))
         cst = CSTParser.parse(text, true)
         doc = new(uri, path, text, nothing, nothing, false, workspace_file, cst, [], 0, server)
         get_line_offsets(doc)


### PR DESCRIPTION
Helps diagnosic https://github.com/julia-vscode/crashreporting-issues/issues/26.

We somehow end up with a relative path for a document there, so we need to figure out how that is slipping in.

For every PR, please check the following:
- [X] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [X] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
