### PR TITLE
Add forgiving mode to get_offset2

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -97,12 +97,12 @@ end
 get_offset(doc, p::Position) = get_offset(doc, p.line, p.character)
 get_offset(doc, r::Range) = get_offset(doc, r.start):get_offset(doc, r.stop)
 
-function get_offset2(doc::Document, line::Integer, character::Integer)
+function get_offset2(doc::Document, line::Integer, character::Integer, forgiving_mode=false)
     line_offsets = get_line_offsets2!(doc)
     text = get_text(doc)
 
     if line >= length(line_offsets)
-        throw(LSOffsetError("get_offset2 crashed. More diagnostics:\nline=$line\nline_offsets='$line_offsets'"))
+        forgiving_mode || throw(LSOffsetError("get_offset2 crashed. More diagnostics:\nline=$line\nline_offsets='$line_offsets'"))
         return nextind(text, lastindex(text))
     elseif line < 0
         throw(LSOffsetError("get_offset2 crashed. More diagnostics:\nline=$line\nline_offsets='$line_offsets'"))

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -272,7 +272,7 @@ function julia_getModuleAt_request(params::VersionedTextDocumentPositionParams, 
     if hasdocument(server, uri)
         doc = getdocument(server, uri)
         if doc._version == params.version
-            offset = get_offset2(doc, params.position.line, params.position.character)
+            offset = get_offset2(doc, params.position.line, params.position.character, true)
             x = get_expr(getcst(doc), offset)
             if x isa EXPR
                 scope = StaticLint.retrieve_scope(x)


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/crashreporting-issues/issues/25.

I don't want to remove these kind of checks for code paths that are "crucial", like say doc sync. But I think for stuff like the get module story, we can be more forgiving. Not super happy, because it still seems to me that we have some bug upstream somewhere, but for now maybe this is ok.

For every PR, please check the following:
- [X] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [X] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
