### PR TITLE
better getModuleAt

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -98,6 +98,7 @@ end
 get_offset(doc, p::Position) = get_offset(doc, p.line, p.character)
 get_offset(doc, r::Range) = get_offset(doc, r.start):get_offset(doc, r.stop)
 
+# 1-based. Basically the index at which (line, character) can be found in the document.
 function get_offset2(doc::Document, line::Integer, character::Integer, forgiving_mode=false)
     line_offsets = get_line_offsets2!(doc)
     text = get_text(doc)

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -272,8 +272,8 @@ function julia_getModuleAt_request(params::VersionedTextDocumentPositionParams, 
     if hasdocument(server, uri)
         doc = getdocument(server, uri)
         if doc._version == params.version
-            offset = get_offset2(doc, params.position.line, params.position.character, true)
-            x = get_expr(getcst(doc), offset)
+            offset = get_offset2(doc, params.position.line, params.position.character)
+            x = get_expr_or_parent(getcst(doc), offset - 1)
             if x isa EXPR
                 scope = StaticLint.retrieve_scope(x)
                 if scope !== nothing

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -272,7 +272,7 @@ function julia_getModuleAt_request(params::VersionedTextDocumentPositionParams, 
     if hasdocument(server, uri)
         doc = getdocument(server, uri)
         if doc._version == params.version
-            offset = get_offset2(doc, params.position.line, params.position.character)
+            offset = get_offset2(doc, params.position.line, params.position.character, true)
             x = get_expr_or_parent(getcst(doc), offset - 1)
             if x isa EXPR
                 scope = StaticLint.retrieve_scope(x)

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -273,7 +273,7 @@ function julia_getModuleAt_request(params::VersionedTextDocumentPositionParams, 
         doc = getdocument(server, uri)
         if doc._version == params.version
             offset = get_offset2(doc, params.position.line, params.position.character, true)
-            x = get_expr_or_parent(getcst(doc), offset - 1)
+            x = get_expr_or_parent(getcst(doc), offset, 1)
             if x isa EXPR
                 scope = StaticLint.retrieve_scope(x)
                 if scope !== nothing

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -207,6 +207,32 @@ function get_expr(x, offset, pos=0, ignorewhitespace=false)
     end
 end
 
+# like get_expr, but only returns a expr if offset is not on the edge of it's span
+function get_expr_or_parent(x, offset, pos=0)
+    if pos > offset
+        return nothing
+    end
+    if length(x) > 0 && headof(x) !== :NONSTDIDENTIFIER
+        for a in x
+            if pos < offset <= (pos + a.fullspan)
+                if pos < offset < (pos + a.span)
+                    return get_expr_or_parent(a, offset, pos)
+                else
+                    return x
+                end
+            end
+            pos += a.fullspan
+        end
+    elseif pos == 0
+        return x
+    elseif (pos < offset <= (pos + x.fullspan))
+        if pos + x.span < offset
+            return x.parent
+        end
+        return x
+    end
+end
+
 function get_expr(x, offset::UnitRange{Int}, pos=0, ignorewhitespace=false)
     if all(pos .> offset)
         return nothing


### PR DESCRIPTION
by ensuring that the offset is inside (not on the edge of) the EXPR's span.

Fixes https://github.com/julia-vscode/julia-vscode/issues/1600 and similar issues (at least when the cursor actually is *outside* of the module definition).

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
