### PR TITLE
allow fuzzy completions

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -3,6 +3,22 @@
 # - fuzzy completions
 # - (maybe) export latex completions into a separate package
 
+using REPL
+
+"""
+    is_completion_match(s::AbstractString, prefix::AbstractString, cutoff=3)
+
+Returns true if `s` starts with `prefix` or has a sufficiently high fuzzy score.
+"""
+function is_completion_match(s::AbstractString, prefix::AbstractString, cutoff=3)
+    starter = if all(islowercase, prefix)
+        startswith(lowercase(s), prefix)
+    else
+        startswith(s, prefix)
+    end
+    starter || REPL.fuzzyscore(prefix, s) >= cutoff
+end
+
 function textDocument_completion_request(params::CompletionParams, server::LanguageServerInstance, conn)
     CIs = CompletionItem[]
     doc = getdocument(server, URI2(params.textDocument.uri))
@@ -68,7 +84,7 @@ end
 
 function latex_completions(doc, offset, partial, CIs)
     for (k, v) in REPL.REPLCompletions.latex_symbols
-        if startswith(string(k), partial)
+        if is_completion_match(string(k), partial)
             t1 = TextEdit(Range(doc, (offset - sizeof(partial)):offset), v)
             push!(CIs, CompletionItem(k, 11, missing, v, v, missing, missing, missing, missing, missing, missing, t1, missing, missing, missing, missing))
         end
@@ -123,13 +139,14 @@ function collect_completions(m::SymbolServer.ModuleStore, spartial, rng, CIs, se
     for val in m.vals
         n, v = String(val[1]), val[2]
         (startswith(n, ".") || startswith(n, "#")) && continue
-        !startswith(n, spartial) && continue
+        !is_completion_match(n, spartial) && continue
         if v isa SymbolServer.VarRef
             v = SymbolServer._lookup(v, getsymbolserver(server), true)
             v === nothing && return
         end
         if StaticLint.isexportedby(n, m) || inclexported
-            push!(CIs, CompletionItem(n, _completion_kind(v, server), MarkupContent(sanitize_docstring(v.doc)), TextEdit(rng, n[nextind(n, sizeof(spartial)):end])))
+            rng1 = Range(Position(rng.start.line, rng.start.character - sizeof(spartial)), rng.stop)
+            push!(CIs, CompletionItem(n, _completion_kind(v, server), MarkupContent(sanitize_docstring(v.doc)), TextEdit(rng1, n)))
         elseif dotcomps
             rng1 = Range(Position(rng.start.line, rng.start.character - sizeof(spartial)), rng.stop)
             push!(CIs, CompletionItem(n, _completion_kind(v, server), MarkupContent(sanitize_docstring(v.doc)), TextEdit(rng1, string(m.name, ".", n))))
@@ -156,13 +173,14 @@ end
 function collect_completions(x::StaticLint.Scope, spartial, rng, CIs, server, inclexported=false, dotcomps=false)
     if x.names !== nothing
         for n in x.names
-            if startswith(n[1], spartial)
+            if is_completion_match(n[1], spartial)
                 documentation = ""
                 if n[2] isa StaticLint.Binding
                     documentation = get_hover(n[2], documentation, server)
                     sanitize_docstring(documentation)
                 end
-                push!(CIs, CompletionItem(n[1], _completion_kind(n[2], server), MarkupContent(documentation), TextEdit(rng, n[1][nextind(n[1], sizeof(spartial)):end])))
+                rng1 = Range(Position(rng.start.line, rng.start.character - sizeof(spartial)), rng.stop)
+                push!(CIs, CompletionItem(n[1], _completion_kind(n[2], server), MarkupContent(documentation), TextEdit(rng1, n[1])))
             end
         end
     end
@@ -189,15 +207,17 @@ function _get_dot_completion(px::EXPR, spartial, rng, CIs, server)
             elseif refof(px).type isa SymbolServer.DataTypeStore
                 for a in refof(px).type.fieldnames
                     a = String(a)
-                    if startswith(a, spartial)
-                        push!(CIs, CompletionItem(a, 2, MarkupContent(a), TextEdit(rng, a[nextind(a, sizeof(spartial)):end])))
+                    if is_completion_match(a, spartial)
+                        rng1 = Range(Position(rng.start.line, rng.start.character - sizeof(spartial)), rng.stop)
+                        push!(CIs, CompletionItem(a, 2, MarkupContent(a), TextEdit(rng1, a)))
                     end
                 end
             elseif refof(px).type isa StaticLint.Binding && refof(px).type.val isa SymbolServer.DataTypeStore
                 for a in refof(px).type.val.fieldnames
                     a = String(a)
-                    if startswith(a, spartial)
-                        push!(CIs, CompletionItem(a, 2, MarkupContent(a), TextEdit(rng, a[nextind(a, sizeof(spartial)):end])))
+                    if is_completion_match(a, spartial)
+                        rng1 = Range(Position(rng.start.line, rng.start.character - sizeof(spartial)), rng.stop)
+                        push!(CIs, CompletionItem(a, 2, MarkupContent(a), TextEdit(rng1, a)))
                     end
                 end
             elseif refof(px).type isa StaticLint.Binding && refof(px).type.val isa EXPR && CSTParser.defines_struct(refof(px).type.val) && scopeof(refof(px).type.val) isa StaticLint.Scope
@@ -247,7 +267,7 @@ end
 function string_completion(doc, offset, rng, t, CIs)
     path_completion(doc, offset, rng, t, CIs)
     # Need to adjust things for quotation marks
-    if t.kind in (CSTParser.Tokenize.Tokens.STRING,CSTParser.Tokenize.Tokens.CMD)
+    if t.kind in (CSTParser.Tokenize.Tokens.STRING, CSTParser.Tokenize.Tokens.CMD)
         t.startbyte < offset <= t.endbyte || return
         relative_offset = offset - t.startbyte - 1
         content = t.val[2:prevind(t.val, lastindex(t.val))]
@@ -326,17 +346,18 @@ is_in_import_statement(x::EXPR) = is_in_fexpr(x, x -> headof(x) in (:using, :imp
 
 function import_completions(doc, offset, rng, ppt, pt, t, is_at_end, x, CIs, server)
     import_statement = StaticLint.get_parent_fexpr(x, x -> headof(x) === :using || headof(x) === :import)
-    
+
     import_root = get_import_root(import_statement)
-    
+
     if (t.kind == CSTParser.Tokens.WHITESPACE && pt.kind ∈ (CSTParser.Tokens.USING, CSTParser.Tokens.IMPORT, CSTParser.Tokens.IMPORTALL, CSTParser.Tokens.COMMA, CSTParser.Tokens.COLON)) ||
         (t.kind in (CSTParser.Tokens.COMMA, CSTParser.Tokens.COLON))
         # no partial, no dot
         if import_root !== nothing && refof(import_root) isa SymbolServer.ModuleStore
             for (n, m) in refof(import_root).vals
                 n = String(n)
-                if startswith(n, t.val) && !startswith(n, "#")
-                    push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng, n[length(t.val) + 1:end])))
+                if is_completion_match(n, t.val) && !startswith(n, "#")
+                    rng1 = Range(doc, offset - sizeof(t.val):offset)
+                    push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng1, n)))
                 end
             end
         else
@@ -358,8 +379,9 @@ function import_completions(doc, offset, rng, ppt, pt, t, is_at_end, x, CIs, ser
                 rootmod = StaticLint.getsymbolserver(server)[Symbol(ppt.val)]
                 for (n, m) in rootmod.vals
                     n = String(n)
-                    if startswith(n, t.val) && !startswith(n, "#")
-                        push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng, n[length(t.val) + 1:end])))
+                    if is_completion_match(n, t.val) && !startswith(n, "#")
+                        rng1 = Range(doc, offset - sizeof(t.val):offset)
+                        push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng1, n)))
                     end
                 end
             end
@@ -367,15 +389,17 @@ function import_completions(doc, offset, rng, ppt, pt, t, is_at_end, x, CIs, ser
             if import_root !== nothing && refof(import_root) isa SymbolServer.ModuleStore
                 for (n, m) in refof(import_root).vals
                     n = String(n)
-                    if startswith(n, t.val) && !startswith(n, "#")
-                        push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng, n[length(t.val) + 1:end])))
+                    if is_completion_match(n, t.val) && !startswith(n, "#")
+                        rng1 = Range(doc, offset - sizeof(t.val):offset)
+                        push!(CIs, CompletionItem(n, _completion_kind(m, server), MarkupContent(m isa SymbolServer.SymStore ? sanitize_docstring(m.doc) : n), TextEdit(rng1, n)))
                     end
                 end
             else
                 for (n, m) in StaticLint.getsymbolserver(server)
                     n = String(n)
-                    if startswith(n, t.val)
-                        push!(CIs, CompletionItem(n, 9, MarkupContent(m isa SymbolServer.SymStore ? m.doc : n), TextEdit(rng, n[nextind(n, sizeof(t.val)):end])))
+                    if is_completion_match(n, t.val)
+                        rng1 = Range(doc, offset - sizeof(t.val):offset)
+                        push!(CIs, CompletionItem(n, 9, MarkupContent(m isa SymbolServer.SymStore ? m.doc : n), TextEdit(rng1, n)))
                     end
                 end
             end


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1988. 
![image](https://user-images.githubusercontent.com/6735977/109941694-b31e8e80-7cd3-11eb-9398-690e57c2b318.png)

Do we want to add an opt-out setting to this? Imho this is unintrusive enough not to need one (JS completions are always fuzzy as well). 

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
