### PR TITLE
fix find_references

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -126,7 +126,8 @@ function find_references(textDocument::TextDocumentIdentifier, position::Positio
     locations = Location[]
     doc = getdocument(server, URI2(textDocument.uri))
     offset = get_offset(doc, position)
-    x = get_expr1(getcst(doc), offset)
+    x = get_identifier(getcst(doc), offset)
+
     if x isa EXPR && StaticLint.hasref(x) && refof(x) isa StaticLint.Binding
         for r in refof(x).refs
             if r isa EXPR


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/912.

Turns out that `get_expr1` on the edge of an identifier sometimes returns the previous one. `get_identifier` doesn't.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
