### PR TITLE
fix kwarg hover printing

### DIFF
--- a/src/requests/hover.jl
+++ b/src/requests/hover.jl
@@ -54,8 +54,9 @@ function get_hover(b::StaticLint.Binding, documentation::String, server)
                 else
                     documentation
                 end
-                documentation = string(documentation, "```julia\n", Expr(b.val), "\n```\n")
+                documentation = string(documentation, "```julia\n", prettify_expr(Expr(b.val)), "\n```\n")
             catch err
+                @error "get_hover failed to convert Expr" exception = (err, catch_backtrace())
                 throw(LSHoverError(string("get_hover failed to convert Expr")))
             end
         end
@@ -64,6 +65,16 @@ function get_hover(b::StaticLint.Binding, documentation::String, server)
     end
     return documentation
 end
+
+function prettify_expr(ex::Expr)
+    if ex.head === :kw && length(ex.args) == 2
+        string(ex.args[1], " = ", ex.args[2])
+    else
+        string(ex)
+    end
+end
+
+prettify_expr(ex) = string(ex)
 
 # print(io, x::SymStore) methods are defined in SymbolServer
 function get_hover(b::SymbolServer.SymStore, documentation::String, server)


### PR DESCRIPTION
Fixes the printing of kwargs in the hover widget.

Before:
![image](https://user-images.githubusercontent.com/6735977/112816680-f1645f00-9081-11eb-8193-f838e8393cb1.png)

After:
![image](https://user-images.githubusercontent.com/6735977/112816607-e01b5280-9081-11eb-88e2-13f97bf92826.png)

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
