### PR TITLE
fix in-module eval for mods with docstrings

### DIFF
--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -40,6 +40,13 @@ function julia_getCurrentBlockRange_request(tdpp::VersionedTextDocumentPositionP
                     end
                 end
 
+                if a.head === :macrocall && a.args[1].head === :globalrefdoc && length(a.args) == 4 && CSTParser.defines_module(a.args[4])
+                    for i in 1:3
+                        loc += a.args[i].fullspan
+                    end
+                    a = a.args[4]
+                end
+
                 if CSTParser.defines_module(a) # Within module at the top-level, lets see if we can select on of the block arguments
                     if loc <= offset <= loc + a.trivia[1].span # Within `module` keyword, so return entire expression
                         return Position(get_position_at(doc, loc)...), Position(get_position_at(doc, loc + a.span)...), Position(get_position_at(doc, loc + a.fullspan)...)

--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -63,7 +63,7 @@ function julia_getCurrentBlockRange_request(tdpp::VersionedTextDocumentPositionP
                             end
                             loc += b.fullspan
                         end
-                    elseif loc + a.trivia[1].fullspan + a.args[2].fullspan + a.args[3].fullspan < offset < loc + a.trivia[1].fullspan + a.args[2].fullspan + a.args[3].fullspan + a.trivia[2].span # Within `end` of the module, so return entire expression
+                    elseif loc + a.trivia[1].fullspan + a.args[2].fullspan + a.args[3].fullspan < offset <= loc + a.trivia[1].fullspan + a.args[2].fullspan + a.args[3].fullspan + a.trivia[2].span # Within `end` of the module, so return entire expression
                         return Position(get_position_at(doc, loc)...), Position(get_position_at(doc, loc + a.span)...), Position(get_position_at(doc, loc + a.fullspan)...)
                     end
                 else

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -207,30 +207,32 @@ function get_expr(x, offset, pos=0, ignorewhitespace=false)
     end
 end
 
-# like get_expr, but only returns a expr if offset is not on the edge of it's span
+# like get_expr, but only returns a expr if offset is not on the edge of its span
 function get_expr_or_parent(x, offset, pos=0)
     if pos > offset
-        return nothing
+        return nothing, pos
     end
+    ppos = pos
     if length(x) > 0 && headof(x) !== :NONSTDIDENTIFIER
         for a in x
             if pos < offset <= (pos + a.fullspan)
                 if pos < offset < (pos + a.span)
                     return get_expr_or_parent(a, offset, pos)
                 else
-                    return x
+                    return x, ppos
                 end
             end
             pos += a.fullspan
         end
     elseif pos == 0
-        return x
+        return x, pos
     elseif (pos < offset <= (pos + x.fullspan))
         if pos + x.span < offset
-            return x.parent
+            return x.parent, ppos
         end
-        return x
+        return x, pos
     end
+    return nothing, pos
 end
 
 function get_expr(x, offset::UnitRange{Int}, pos=0, ignorewhitespace=false)


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2078.

Now also has a few more improvements regarding the specifics of `getModuleAt` and `getBlockRange` around modules.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
