### PR TITLE
fix markdown hover URIs for VSCode

### DIFF
--- a/src/requests/hover.jl
+++ b/src/requests/hover.jl
@@ -94,12 +94,17 @@ function get_hover(f::SymbolServer.FunctionStore, documentation::String, server)
         end
         print(io, ")")
         sig = String(take!(io))
-        mod = m.mod
-        text = string(m.file, ':', m.line)
-        # VSCode markdown doesn't seem to be able to handle line number in links
-        # link = string(normpath(m.file), ':', m.line)
-        link = normpath(m.file)
-        documentation = string(documentation, "- `$(sig)` in `$(mod)` at [$(text)]($(link))", '\n')
+
+        text = replace(string(m.file, ':', m.line), "\\" => "\\\\")
+        link = text
+
+        if server.clientInfo !== missing
+            if occursin("code", lowercase(server.clientInfo.name))
+                link = string(filepath2uri(m.file), "#", m.line)
+            end
+        end
+
+        documentation = string(documentation, "- `$(sig)` in `$(m.mod)` at [$(text)]($(link))", '\n')
     end
     return documentation
 end


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/2108. Tested on Linux and Windows.

Also directly goes to the correct line for VSCode clients.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
