### PR TITLE
fix 280

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -269,10 +269,13 @@ function parse_jmd(ps, str)
             end
             prec_str_size = currentbyte:startbyte + ps.nt.startbyte + 3
 
-            push!(top.args, EXPR(:STRING, length(prec_str_size), length(prec_str_size)))
+            push!(top, EXPR(:STRING, length(prec_str_size), length(prec_str_size)))
 
             args, ps = CSTParser.parse(ps, true)
-            append!(top.args, args.args)
+            for a in args.args
+                push!(top, a)
+            end
+
             CSTParser.update_span!(top)
             currentbyte = top.fullspan + 1
         elseif CSTParser.ismacrocall(b) && headof(b.args[1]) === :globalrefcmd && headof(b.args[3]) === :STRING && b.val !== nothing && startswith(b.val, "j ")
@@ -280,17 +283,20 @@ function parse_jmd(ps, str)
             ps = CSTParser.ParseState(blockstr)
             CSTParser.next(ps)
             prec_str_size = currentbyte:startbyte + ps.nt.startbyte + 1
-            push!(top.args, EXPR(:STRING, length(prec_str_size), length(prec_str_size)))
+            push!(top, EXPR(:STRING, length(prec_str_size), length(prec_str_size)))
 
             args, ps = CSTParser.parse(ps, true)
-            append!(top.args, args.args)
+            for a in args.args
+                push!(top, a)
+            end
+            
             CSTParser.update_span!(top)
             currentbyte = top.fullspan + 1
         end
     end
 
     prec_str_size = currentbyte:sizeof(str) # OK
-    push!(top.args, EXPR(:STRING, length(prec_str_size), length(prec_str_size)))
+    push!(top, EXPR(:STRING, length(prec_str_size), length(prec_str_size)))
     CSTParser.update_span!(top)
 
     return top, ps


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/StaticLint.jl/issues/280

Previously we were pushing arguments to the top expresions .args field directly, rather than using the specialised `push!(expr::EXPR,item)`. The specialised version makes sure the parent of each `item` is set to `expr`.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
