### PR TITLE
improve snippet completions

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -95,7 +95,8 @@ function kw_completion(doc, spartial, CIs, offset)
     length(spartial) == 0 && return
     for (kw, comp) in snippet_completions
         if startswith(kw, spartial)
-            push!(CIs, CompletionItem(kw, 14, missing, missing, kw, missing, missing, missing, missing, missing, InsertTextFormats.Snippet, TextEdit(Range(doc, offset:offset), comp[length(spartial) + 1:end]), missing, missing, missing, missing))
+             t1 = TextEdit(Range(doc, (offset - sizeof(spartial)):offset), comp)
+            push!(CIs, CompletionItem(kw, 14, missing, missing, kw, missing, missing, missing, missing, missing, InsertTextFormats.Snippet, t1, missing, missing, missing, missing))
         end
     end
 end


### PR DESCRIPTION
Makes our kw completions consistent with all other completions. We now return
```
[Trace - 12:27:30] Received response 'textDocument/completion - (7)' in 422ms.
Result: {
    "isIncomplete": true,
    "items": [
        {
            "label": "import",
            "kind": 14,
            "documentation": "import",
            "insertTextFormat": 2,
            "textEdit": {
                "range": {
                    "start": {
                        "line": 7,
                        "character": 0
                    },
                    "end": {
                        "line": 7,
                        "character": 3
                    }
                },
                "newText": "import"
            }
        }
    ]
}
```
for `imp\tab` instead of an empty range followed by the missing part of the snippet.

Ref https://github.com/fannheyward/coc-julia/commit/af04e94e0594fb87a5a2bd641ff8b87798a759cb.