### PR TITLE
Use file URIs for MD links in hover popups for Sublime too

### DIFF
--- a/src/requests/hover.jl
+++ b/src/requests/hover.jl
@@ -110,8 +110,9 @@ function get_hover(f::SymbolServer.FunctionStore, documentation::String, server)
         text = replace(string(m.file, ':', m.line), "\\" => "\\\\")
         link = text
 
-        if server.clientInfo !== missing
-            if occursin("code", lowercase(server.clientInfo.name)) && isabspath(m.file)
+        if server.clientInfo !== missing && isabspath(m.file)
+            clientname = lowercase(server.clientInfo.name)
+            if occursin("code", clientname) || occursin("sublime", clientname)
                 link = string(filepath2uri(m.file), "#", m.line)
             end
         end


### PR DESCRIPTION
The LSP client for Sublime Text doesn't support (anymore) the filepath:line format as it is used for Markdown link destinations to other files in hover results. There is some special casing by the server for VS Code to use a file URIs with a `#line` suffix, and those can be handled by the Sublime Text client (on the latest `main` branch) too, so this change would restore the functionality to open file links there. The name used in `clientInfo` is "Sublime Text LSP".

I haven't checked if the file URI format is supported by the other clients for Emacs/vim too, but perhaps this special check for VSCode (and now Sublime) could even be removed completely in favor of always using file URIs instead.