### PR TITLE
add nothing check to get_file_level_parent

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -484,6 +484,9 @@ function get_file_level_parent(x::EXPR)
     if x.parent isa EXPR && x.parent.head === :file
         x
     else
+        if x.parent === nothing
+            return nothing
+        end
         get_file_level_parent(x.parent)
     end
 end


### PR DESCRIPTION
Fixes [an issue from crash reporting](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%226803c4ed-bcb4-41d4-bceb-7faf5e7a3469%22%2C%22ResourceGroup%22%3A%22Default%22%2C%22Name%22%3A%22julia-vscode-insider%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F6803c4ed-bcb4-41d4-bceb-7faf5e7a3469%252FresourceGroups%252FDefault%252Fproviders%252Fmicrosoft.insights%252Fcomponents%252Fjulia-vscode-insider%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%22f2278151-c6ce-11eb-bc21-e9b6e5daa981%22%2C%22timestamp%22%3A%222021-06-06T13%3A56%3A09.025Z%22%2C%22cacheId%22%3A%22b6685c1c-657b-46ca-a954-a0e37a5c23bc%22%2C%22eventTable%22%3A%22exceptions%22%7D).
