### PR TITLE
remove hover message for closing function call parenthesis

### DIFF
--- a/src/requests/hover.jl
+++ b/src/requests/hover.jl
@@ -221,10 +221,6 @@ function get_closer_hover(x::EXPR, documentation)
             else
                 documentation = "Closes `$(headof(parentof(x)))` expression."
             end
-        elseif headof(x) === :RPAREN
-            if CSTParser.iscall(parentof(x)) && length(parentof(x).args) > 0
-                documentation = string(documentation, "Closes call of ", Expr(parentof(x).args[1]), "\n")
-            end
         end
     end
     return documentation

--- a/test/requests/hover.jl
+++ b/test/requests/hover.jl
@@ -43,5 +43,6 @@ S(a,b,c,d,e,f,g)
 @test hover_test(12, 14) !== nothing
 @test hover_test(13, 13) !== nothing
 @test hover_test(14, 7) !== nothing
-@test hover_test(15, 5) !== nothing
+@test hover_test(15, 2) !== nothing
+@test hover_test(15, 5) === nothing
 @test hover_test(25, 15) !== nothing


### PR DESCRIPTION
because these are already indicated by highlighting the matching paren anyways.