### PR TITLE
Fix env_project_file usage

### DIFF
--- a/src/multienv.jl
+++ b/src/multienv.jl
@@ -24,7 +24,9 @@ function env_file(env::String, names = project_names)::Union{Nothing,String}
 end
 
 function is_project_folder_in_env(folder, env_manifest, server)
-    folder_proj = parsed_toml(env_project_file(folder))
+    project_file = Base.env_project_file(folder)
+    project_file isa Bool && return false
+    folder_proj = parsed_toml(project_file)
     manifest_pe = get(env_manifest, get(folder_proj, "uuid", ""), nothing)
     if manifest_pe === nothing
         return false


### PR DESCRIPTION
There were two problems: 1) it didn't use `Base.env_project_file`, and that symbol isn't exported, so I doubt this was ever even called, and 2) we need to handle a `Bool` return value.

I'm also not entirely sure whether the semantics I'm using here make a lot of sense, but it at least should fix a runtime error, hopefully.