### PR TITLE
additional error handling in get_env_for_root

### DIFF
--- a/src/multienv.jl
+++ b/src/multienv.jl
@@ -56,31 +56,45 @@ function get_env_for_root(doc::Document, server::LanguageServerInstance)
     parent_workspaceFolder = first(parent_workspaceFolders)
 
     project_env = env_file(parent_workspaceFolder, project_names)
-    if safe_isfile(project_env)
-        folder_proj = parsed_toml(project_env)
+    try
+        if safe_isfile(project_env)
+            folder_proj = parsed_toml(project_env)
 
-        # We point to all caches as, though a package may not be directly available (e.g as
-        # a dependency) it may still be accessible as imported by one of the direct dependencies.
-        symbols = server.global_env.symbols
+            # We point to all caches as, though a package may not be directly available (e.g as
+            # a dependency) it may still be accessible as imported by one of the direct dependencies.
+            symbols = server.global_env.symbols
 
-        # Will want to limit this to only get extended methods from the dependency tree of
-        # the project (e.g. using `complete_dep_tree` below)
-        extended_methods = server.global_env.extended_methods
+            # Will want to limit this to only get extended methods from the dependency tree of
+            # the project (e.g. using `complete_dep_tree` below)
+            extended_methods = server.global_env.extended_methods
 
-        # This is the list of packages that are directly available
-        project_deps = Symbol.(collect(keys(get(folder_proj, "deps", []))))
-        if isdir(joinpath(parent_workspaceFolder, "test")) && startswith(doc._path, joinpath(parent_workspaceFolder, "test"))
-            # We're in the test folder, add the project iteself to the deps
-            # This should actually point to the live code (e.g. the relevant EXPR or Scope)?
-            haskey(folder_proj, "name") && push!(project_deps, Symbol(folder_proj["name"]))
-            for extra in keys(get(folder_proj, "extras", []))
-                if Symbol(extra) in keys(symbols)
-                    push!(project_deps, Symbol(extra))
+            # This is the list of packages that are directly available
+            project_deps = Symbol.(collect(keys(get(folder_proj, "deps", []))))
+            if isdir(joinpath(parent_workspaceFolder, "test")) && startswith(doc._path, joinpath(parent_workspaceFolder, "test"))
+                # We're in the test folder, add the project iteself to the deps
+                # This should actually point to the live code (e.g. the relevant EXPR or Scope)?
+                haskey(folder_proj, "name") && push!(project_deps, Symbol(folder_proj["name"]))
+                for extra in keys(get(folder_proj, "extras", []))
+                    if Symbol(extra) in keys(symbols)
+                        push!(project_deps, Symbol(extra))
+                    end
                 end
             end
-        end
 
-        StaticLint.ExternalEnv(symbols, extended_methods, project_deps)
+            StaticLint.ExternalEnv(symbols, extended_methods, project_deps)
+        end
+    catch err
+        # The specified env is faulty (incorrect format, missing entries, ...)
+        # We can't do anything about that except treating it the same as a non-existing env,
+        # but showing a warning might be useful.
+        msg = "The Julia environment at `$project_env` is invalid. Using the global environment instead."
+        if server.jr_endpoint !== nothing
+            JSONRPC.send(server.jr_endpoint, window_showMessage_notification_type, ShowMessageParams(
+                MessageTypes.Warning,
+                msg
+            ))
+        end
+        @error msg exception=(err, catch_backtrace())
     end
 end
 

--- a/src/protocol/messagedefs.jl
+++ b/src/protocol/messagedefs.jl
@@ -41,7 +41,7 @@ const setTraceNotification_notification_type = JSONRPC.NotificationType("\$/setT
 
 const window_workDoneProgress_create_request_type = JSONRPC.RequestType("window/workDoneProgress/create", WorkDoneProgressCreateParams, Nothing)
 const window_showMessage_notification_type = JSONRPC.NotificationType("window/showMessage", ShowMessageParams)
-const window_showMessage_request_type = JSONRPC.NotificationType("window/showMessageRequest", ShowMessageRequestParams)
+const window_showMessage_request_type = JSONRPC.RequestType("window/showMessageRequest", ShowMessageRequestParams, Union{MessageActionItem, Nothing})
 
 const progress_notification_type = JSONRPC.NotificationType("\$/progress", ProgressParams)
 

--- a/src/protocol/messagedefs.jl
+++ b/src/protocol/messagedefs.jl
@@ -40,7 +40,8 @@ const setTrace_notification_type = JSONRPC.NotificationType("\$/setTrace", SetTr
 const setTraceNotification_notification_type = JSONRPC.NotificationType("\$/setTraceNotification", Nothing)
 
 const window_workDoneProgress_create_request_type = JSONRPC.RequestType("window/workDoneProgress/create", WorkDoneProgressCreateParams, Nothing)
-const window_showMessage_notification_type = JSONRPC.NotificationType("window/showMessage", ShowMessageRequestParams)
+const window_showMessage_notification_type = JSONRPC.NotificationType("window/showMessage", ShowMessageParams)
+const window_showMessage_request_type = JSONRPC.NotificationType("window/showMessageRequest", ShowMessageRequestParams)
 
 const progress_notification_type = JSONRPC.NotificationType("\$/progress", ProgressParams)
 


### PR DESCRIPTION
Fixes an issue from [crash reporting](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%226803c4ed-bcb4-41d4-bceb-7faf5e7a3469%22%2C%22ResourceGroup%22%3A%22Default%22%2C%22Name%22%3A%22julia-vscode-insider%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F6803c4ed-bcb4-41d4-bceb-7faf5e7a3469%252FresourceGroups%252FDefault%252Fproviders%252Fmicrosoft.insights%252Fcomponents%252Fjulia-vscode-insider%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%22edec0c20-ef3f-11eb-9455-897edacf0cc8%22%2C%22timestamp%22%3A%222021-07-28T01%3A05%3A41.041Z%22%2C%22cacheId%22%3A%22334bcabe-67dc-4237-bef5-6cba9da6a60f%22%2C%22eventTable%22%3A%22exceptions%22%7D).

Also fixes the definition of `showMessage` and `showMessageRequest`.