### PR TITLE
fix CompletionState method error

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -6,7 +6,7 @@ struct CompletionState
     offset::Int
     completions::Dict{String,CompletionItem}
     range::Range
-    x::EXPR
+    x::Union{Nothing, EXPR}
     doc::Document
     server::LanguageServerInstance
     using_stmts::Dict{String,Any}
@@ -89,9 +89,9 @@ function textDocument_completion_request(params::CompletionParams, server::Langu
         state.x !== nothing && collect_completions(state.x, "@", state, false)
     elseif t isa CSTParser.Tokens.Token && Tokens.iskeyword(t.kind) && is_at_end
         kw_completion(CSTParser.Tokenize.untokenize(t), state)
-    elseif t isa CSTParser.Tokens.Token && t.kind == CSTParser.Tokens.IN && is_at_end
+    elseif t isa CSTParser.Tokens.Token && t.kind == CSTParser.Tokens.IN && is_at_end && state.x !== nothing
         collect_completions(state.x, "in", state, false)
-    elseif t isa CSTParser.Tokens.Token && t.kind == CSTParser.Tokens.ISA && is_at_end
+    elseif t isa CSTParser.Tokens.Token && t.kind == CSTParser.Tokens.ISA && is_at_end && state.x !== nothing
         collect_completions(state.x, "isa", state, false)
     end
 


### PR DESCRIPTION
Fixes a [method error](https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%226803c4ed-bcb4-41d4-bceb-7faf5e7a3469%22%2C%22ResourceGroup%22%3A%22Default%22%2C%22Name%22%3A%22julia-vscode-insider%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F6803c4ed-bcb4-41d4-bceb-7faf5e7a3469%252FresourceGroups%252FDefault%252Fproviders%252Fmicrosoft.insights%252Fcomponents%252Fjulia-vscode-insider%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%22731a4fb5-07d7-11ec-bfec-a77f3c04ebb5%22%2C%22timestamp%22%3A%222021-08-28T08%3A10%3A47.524Z%22%2C%22cacheId%22%3A%2222efd05f-07cc-4ad2-908d-c17cf4e9a7fd%22%2C%22eventTable%22%3A%22exceptions%22%7D) in the CompletionState constructor.