### PR TITLE
keep style option from .JuliaFormatter.toml

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -176,7 +176,7 @@ function format_text(text::AbstractString, params, config)
         return JuliaFormatter.format_text(text; default_juliaformatter_config(params)...)
     else
         # Some valid options in config file are not valid for format_text
-        VALID_OPTIONS = fieldnames(JuliaFormatter.Options)
+        VALID_OPTIONS = (fieldnames(JuliaFormatter.Options)..., :style)
         config = filter(p -> in(first(p), VALID_OPTIONS), JuliaFormatter.kwargs(config))
         return JuliaFormatter.format_text(text; config...)
     end


### PR DESCRIPTION
Patches #1029

style is not within JuliaFormatter.Options

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
