### PR TITLE
Make no whitespace around kwargs default

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -146,7 +146,8 @@ function default_juliaformatter_config(params)
         join_lines_based_on_source = true,
         trailing_comma = nothing,
         margin = 10_000,
-        always_for_in = nothing
+        always_for_in = nothing,
+        whitespace_in_kwargs = false
     )
 end
 


### PR DESCRIPTION
This matches the old DocumentFormat.jl default.

Without this we will have a massive, massive reformatting happening all over the place via package butler.