### PR TITLE
Fix get_file_loc for generators

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,4 +95,7 @@ end
     @testset "paths" begin
         include("test_paths.jl")
     end
+    @testset "misc" begin
+        include("test_misc.jl")
+    end
 end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,0 +1,5 @@
+@testset "get_file_loc" begin
+    str = "(x+y for x in X for y in Y if begin if true end end)"
+    cst = CSTParser.parse(str)
+    @test LanguageServer.get_file_loc(cst[2][5][1][1]) == (nothing, 20)
+end


### PR DESCRIPTION
This is more inefficient but also more correct.

Crucially, we can't rely on the fact that iterating over `parentof(x)` will yield `x` at any point. This basically only comes up with generators, so it might make more sense to fix the iteration protocol instead.