### PR TITLE
More robust is_latex_comp

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -333,7 +333,8 @@ function string_completion(t, state::CompletionState)
 end
 
 function is_latex_comp(s, i)
-    i0 = i
+    firstindex(s) <= i <= lastindex(s) || return ""
+    i0 = i = thisind(s, i)
     while firstindex(s) <= i
         s[i] == '\\' && return s[i:i0]
         !is_latex_comp_char(s[i]) && return ""


### PR DESCRIPTION
Fixes an issue from crash-reporting:
``` 
StringIndexError:
   at string_index_err(s::String, i::Int64) (string.jl:12)
   at getindex_continued(s::String, i::Int64, u::UInt32) (string.jl:233)
   at getindex (string.jl:226)
   at is_latex_comp(s::String, i::Int64) (.\julialang.language-julia-1.6.10\scripts\packages\LanguageServer\src\requests\completions.jl:338)
   at textDocument_completion_request(params::LanguageServer.CompletionParams, server::LanguageServerInstance, conn::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint, Base.PipeEndpoint}) (.\julialang.language-julia-1.6.10\scripts\packages\LanguageServer\src\requests\completions.jl:58)
   at (::LanguageServer.var"#97#98"{typeof(LanguageServer.textDocument_completion_request), LanguageServerInstance})(conn::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint, Base.PipeEndpoint}, params::LanguageServer.CompletionParams) (.\julialang.language-julia-1.6.10\scripts\packages\LanguageServer\src\languageserverinstance.jl:251)
   at dispatch_msg(x::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint, Base.PipeEndpoint}, dispatcher::JSONRPC.MsgDispatcher, msg::Dict{String, Any}) (.\julialang.language-julia-1.6.10\scripts\packages\JSONRPC\src\typed.jl:67)
   at run(server::LanguageServerInstance) (.\julialang.language-julia-1.6.10\scripts\packages\LanguageServer\src\languageserverinstance.jl:369)
   at top-level scope (.\julialang.language-julia-1.6.10\scripts\languageserver\main.jl:96)
   at eval (boot.jl:373)
   at include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String) (loading.jl:1196)
   at _include(mapexpr::Function, mod::Module, _path::String) (loading.jl:1253)
   at include(mod::Module, _path::String) (Base.jl:418)
   at exec_options(opts::Base.JLOptions) (client.jl:292)
   at _start() (client.jl:495)
   ```

Fixes https://github.com/julia-vscode/crashreporting-issues/issues/50.