### PR TITLE
Completion for string macros

### DIFF
--- a/test/requests/completions.jl
+++ b/test/requests/completions.jl
@@ -118,6 +118,21 @@ end
 
     settestdoc("isa")
     @test any(item.label == "isa" for item in completion_test(0, 3).items)
+
+    # String macros
+    settestdoc("uint12")
+    @test any(item.label == "uint128\"" for item in completion_test(0, 6).items)
+    @test any(item.label == "@uint128_str" for item in completion_test(0, 6).items)
+
+    settestdoc("@uint12")
+    @test any(item.label == "@uint128_str" for item in completion_test(0, 7).items)
+
+    settestdoc("""
+    macro foobar_str(ex) ex end
+    fooba
+    """)
+    @test any(item.label == "foobar\"" for item in completion_test(1, 5).items)
+    @test any(item.label == "@foobar_str" for item in completion_test(1, 5).items)
 end
 
 @testset "scope var completions" begin


### PR DESCRIPTION
This implements completions for string macros to allow them to complete
without the initial `at` and trailing `_str`. For example, `artif`
completes to `artifact"` like in the REPL. If the completion mode is set
to `:import` the real name is imported (`using Pkg: at-artifact_str`),
and when the completion mode is `:qualify` the qualified string macro is
inserted (`Pkg.artifact"`).