### PR TITLE
Implement code action to replace ==/!= with ===/!==

### DIFF
--- a/test/requests/actions.jl
+++ b/test/requests/actions.jl
@@ -49,3 +49,12 @@ end
     
     LanguageServer.workspace_executeCommand_request(LanguageServer.ExecuteCommandParams(missing, c.command, c.arguments), server, server.jr_endpoint)
 end
+
+@testset "===/!== for nothing comparison" begin
+    for str in ("x = 1\nif x == nothing end", "x = 1\nif x != nothing end")
+        doc = settestdoc(str)
+        @test any(c.command == "CompareNothingWithTripleEqual" for c in action_request_test(1, 6))
+        c = filter(c -> c.command == "CompareNothingWithTripleEqual", action_request_test(1, 6))[1]
+        LanguageServer.workspace_executeCommand_request(LanguageServer.ExecuteCommandParams(missing, c.command, c.arguments), server, server.jr_endpoint)
+    end
+end


### PR DESCRIPTION
This implements a new code action, CompareNothingWithTripleEqual, which
offers to replace == and != with === and !==, respectively, for the
corresponding linter warning(s).