### PR TITLE
Use snippet kind for keyword completions which include tab stops

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -118,7 +118,8 @@ function kw_completion(partial::String, state::CompletionState)
     length(partial) == 0 && return
     for (kw, comp) in snippet_completions
         if startswith(kw, partial)
-            add_completion_item(state, CompletionItem(kw, CompletionItemKinds.Keyword, missing, missing, kw, missing, missing, missing, missing, missing, InsertTextFormats.Snippet, texteditfor(state, partial, comp), missing, missing, missing, missing))
+            kind = occursin("\$0", comp) ? CompletionItemKinds.Snippet : CompletionItemKinds.Keyword
+            add_completion_item(state, CompletionItem(kw, kind, missing, missing, kw, missing, missing, missing, missing, missing, InsertTextFormats.Snippet, texteditfor(state, partial, comp), missing, missing, missing, missing))
         end
     end
 end


### PR DESCRIPTION
This PR proposes to use the "Snippet" kind for keyword completions, which include tab stops (`$0`, `$1`, ....) and in most cases multiple lines.

The kind is used for the icon in the completions popup and could for example also be used by clients to filter out snippet completions if users don't want to see them.