### PR TITLE
New server option to replace unused function argument with underscore

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -43,6 +43,7 @@ mutable struct LanguageServerInstance
     lint_missingrefs::Symbol
     lint_disableddirs::Vector{String}
     completion_mode::Symbol
+    unused_argument::Symbol
 
     combined_msg_queue::Channel{Any}
 
@@ -80,6 +81,7 @@ mutable struct LanguageServerInstance
             :all,
             LINT_DIABLED_DIRS,
             :qualify, # options: :import or :qualify, anything else turns this off
+            :type,    # options: :type or :underscore
             Channel{Any}(Inf),
             err_handler,
             :created,

--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -311,11 +311,11 @@ function remove_farg_name(x, server, conn)
     file, offset = get_file_loc(x1)
     if CSTParser.isdeclaration(x1)
         tde = TextDocumentEdit(VersionedTextDocumentIdentifier(file._uri, file._version), TextEdit[
-                        TextEdit(Range(file, offset .+ (0:x1.args[1].fullspan)), "")
+                        TextEdit(Range(file, offset .+ (0:x1.args[1].fullspan)), server.unused_argument === :underscore ? "_" : "")
                     ])
     else
         tde = TextDocumentEdit(VersionedTextDocumentIdentifier(file._uri, file._version), TextEdit[
-                        TextEdit(Range(file, offset .+ (0:x1.fullspan)), "::Any")
+                        TextEdit(Range(file, offset .+ (0:x1.fullspan)), server.unused_argument === :underscore ? "_" : "::Any")
                     ])
     end
     JSONRPC.send(conn, workspace_applyEdit_request_type, ApplyWorkspaceEditParams(missing, WorkspaceEdit(missing, TextDocumentEdit[tde])))

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -99,7 +99,8 @@ function request_julia_config(server::LanguageServerInstance, conn)
         ConfigurationItem(missing, "julia.lint.run"),
         ConfigurationItem(missing, "julia.lint.missingrefs"),
         ConfigurationItem(missing, "julia.lint.disabledDirs"),
-        ConfigurationItem(missing, "julia.completionmode")
+        ConfigurationItem(missing, "julia.completionmode"),
+        ConfigurationItem(missing, "julia.unusedargument"),
     ]))
 
     new_runlinter = something(response[11], true)
@@ -108,6 +109,7 @@ function request_julia_config(server::LanguageServerInstance, conn)
     new_lint_missingrefs = Symbol(something(response[12], :all))
     new_lint_disableddirs = something(response[13], LINT_DIABLED_DIRS)
     new_completion_mode = Symbol(something(response[14], :import))
+    new_unused_argument = Symbol(something(response[15], :type))
 
     rerun_lint = begin
         any(getproperty(server.lint_options, opt) != getproperty(new_SL_opts, opt) for opt in fieldnames(StaticLint.LintOptions)) ||
@@ -121,6 +123,7 @@ function request_julia_config(server::LanguageServerInstance, conn)
     server.lint_missingrefs = new_lint_missingrefs
     server.lint_disableddirs = new_lint_disableddirs
     server.completion_mode = new_completion_mode
+    server.unused_argument = new_unused_argument
 
     if rerun_lint
         relintserver(server)


### PR DESCRIPTION
This implements a new option, `julia.unusedargument`, which can be set
to either `"type"` (default) or `"underscore"`. This option affects the
replacement offered by the remove-unused-argumentname code action. The
default (`"type"`) is to replace `foo` with `::Any`, and `bar::Int` with
`::Int`. When the option is set to `"underscore"` the offered
replacement is instead `_` and `_::Int`, respectively.