### PR TITLE
Type a field correctly as DocumentUri

### DIFF
--- a/src/protocol/configuration.jl
+++ b/src/protocol/configuration.jl
@@ -41,7 +41,7 @@ const WatchKinds = (Create = 1,
 
 
 @dict_readable struct FileEvent
-    uri::String
+    uri::DocumentUri
     type::FileChangeType
 end
 


### PR DESCRIPTION
Fixes a bug from crash reporting related to the new uri stuff.