### PR TITLE
Fix missing URI conversion in code action execution.

### DIFF
--- a/src/URIs2/URIs2.jl
+++ b/src/URIs2/URIs2.jl
@@ -30,6 +30,8 @@ function URI(value::AbstractString)
     )
 end
 
+URI(uri::URI) = uri
+
 function URI(;
     scheme::Union{AbstractString,Nothing}=nothing,
     authority::Union{AbstractString,Nothing}=nothing,

--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -75,7 +75,7 @@ function textDocument_codeAction_request(params::CodeActionParams, server::Langu
 end
 
 function workspace_executeCommand_request(params::ExecuteCommandParams, server::LanguageServerInstance, conn)
-    uri = params.arguments[1]
+    uri = URI(params.arguments[1])
     offset = params.arguments[2]
     doc = getdocument(server, uri)
     x = get_expr(getcst(doc), offset)

--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -75,11 +75,11 @@ function textDocument_codeAction_request(params::CodeActionParams, server::Langu
 end
 
 function workspace_executeCommand_request(params::ExecuteCommandParams, server::LanguageServerInstance, conn)
-    uri = URI(params.arguments[1])
-    offset = params.arguments[2]
-    doc = getdocument(server, uri)
-    x = get_expr(getcst(doc), offset)
     if haskey(LSActions, params.command)
+        uri = URI(params.arguments[1])
+        offset = params.arguments[2]
+        doc = getdocument(server, uri)
+        x = get_expr(getcst(doc), offset)
         LSActions[params.command].handler(x, server, conn)
     end
 end


### PR DESCRIPTION
I am confused how CI passed without this, this path should be tested by https://github.com/julia-vscode/LanguageServer.jl/blob/0955a4d6e6bf1f88809054f4b18e9674445f1ad3/test/requests/actions.jl#L8 etc.