### PR TITLE
Implement basic code action for import/using organization.

### DIFF
--- a/src/protocol/features.jl
+++ b/src/protocol/features.jl
@@ -18,7 +18,7 @@ const CodeActionKinds = (Empty = "",
                          RefactorInline = "refactor.inline",
                          RefactorRewrite = "refactor.rewrite",
                          Source = "source",
-                         SourceOrganizeImports = "source.organiseImports")
+                         SourceOrganizeImports = "source.organizeImports")
 
 @dict_readable struct CodeActionKindCapabilities
     valueSet::Vector{CodeActionKind}

--- a/test/requests/actions.jl
+++ b/test/requests/actions.jl
@@ -82,3 +82,14 @@ end
 
     LanguageServer.workspace_executeCommand_request(LanguageServer.ExecuteCommandParams(missing, c.command, c.arguments), server, server.jr_endpoint)
 end
+
+@testset "Organize imports" begin
+    doc = settestdoc("using JSON\nusing Example: foo, bar\nf(x) = x\n")
+
+    @test any(c.command == "OrganizeImports" for c in action_request_test(0, 1))
+    @test any(c.command == "OrganizeImports" for c in action_request_test(1, 10))
+    @test !any(c.command == "OrganizeImports" for c in action_request_test(2, 2))
+
+    c = filter(c -> c.command == "OrganizeImports", action_request_test(0, 1))[1]
+    LanguageServer.workspace_executeCommand_request(LanguageServer.ExecuteCommandParams(missing, c.command, c.arguments), server, server.jr_endpoint)
+end


### PR DESCRIPTION
This organizes the using/import statement under the cursor, together
with any older/younger sibling expressions. The output format is close
to 'BlueStyle': import before using, and sorted alphabetically.
