### PR TITLE
Replace broken display methods with working show methods.

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -19,7 +19,9 @@ mutable struct Document
     end
 end
 
-Base.display(doc::Document) = println("Doc: $(basename(doc._uri)) ")
+function Base.show(io::IO, ::MIME"text/plain", doc::Document)
+    print(io, "Document: ", get_uri(doc))
+end
 
 function set_doc(x::EXPR, doc)
     if !StaticLint.hasmeta(x)

--- a/src/textdocument.jl
+++ b/src/textdocument.jl
@@ -17,7 +17,9 @@ struct TextDocument
     end
 end
 
-Base.display(doc::TextDocument) = println("TextDocument: $(basename(doc._uri)) ")
+function Base.show(io::IO, ::MIME"text/plain", doc::TextDocument)
+    print(io, "TextDocument: ", doc._uri)
+end
 
 get_text(doc::TextDocument) = doc._content
 

--- a/test/test_document.jl
+++ b/test/test_document.jl
@@ -135,3 +135,10 @@ end
     @test length(links) == 1
     @test links[1].target == LS.filepath2uri(@__FILE__)
 end
+
+@testset "Base.show for (Text)Document" begin
+    tdoc = LanguageServer.TextDocument(LanguageServer.URIs2.URI("file:///tmp/foo.jl"), "foo", 0)
+    @test sprint(show, MIME("text/plain"), tdoc) == "TextDocument: file:///tmp/foo.jl"
+    doc = LanguageServer.Document(tdoc, false)
+    @test sprint(show, MIME("text/plain"), doc) == "Document: file:///tmp/foo.jl"
+end


### PR DESCRIPTION
`Document` doesn't have a `._uri` field any more. In addition, defining
methods for `display(::X)` is rather unconventional, so this replaces
two such methods of `display` with `Base.show(::IO, ::MIME, ::X)`.