### PR TITLE
Fix string conversion code action in docstrings

### DIFF
--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -502,10 +502,19 @@ function is_string_literal(x::EXPR; inraw::Bool=false)
             # x is part of a string with interpolation
             return false
         end
-        # check for literal string macro: return false for eg. foo"bar" even though "bar" is considered a string literal
-        if x.parent isa EXPR && CSTParser.ismacrocall(x.parent) && endswith(x.parent.args[1].val, "_str") &&
-            ncodeunits(x.parent.args[1].val) - ncodeunits("@_str") == x.parent.args[1].span
-            return inraw ? x.parent.args[1].val == "@raw_str" : false
+        # Special handling if the string was found inside a macro
+        if x.parent isa EXPR && CSTParser.ismacrocall(x.parent)
+            if x.parent.args[1] isa EXPR && headof(x.parent.args[1]) === :IDENTIFIER &&
+               endswith(x.parent.args[1].val, "_str") &&
+               ncodeunits(x.parent.args[1].val) - ncodeunits("@_str") == x.parent.args[1].span
+                # Disable for literal string macros, foo"...", but allow @foo_str "..."
+                return inraw ? x.parent.args[1].val == "@raw_str" : false
+            elseif x.parent.args[1] isa EXPR && headof(x.parent.args[1]) === :globalrefdoc
+                # Disable action for docstrings
+                return false
+            else
+                # Just some other macro, e.g. @show "hello", allow
+            end
         end
         return inraw ? false : true
     end

--- a/test/requests/actions.jl
+++ b/test/requests/actions.jl
@@ -106,6 +106,9 @@ end
         r"not fine"
 
         "not \$(fine) either"
+
+        "docstring"
+        f(x) = x
         """)
 
     @test any(c.command == "RewriteAsRawString" for c in action_request_test(0, 2))
@@ -113,6 +116,7 @@ end
     @test any(c.command == "RewriteAsRawString" for c in action_request_test(4, 12))
     @test !any(c.command == "RewriteAsRawString" for c in action_request_test(6, 4))
     @test !any(c.command == "RewriteAsRawString" for c in action_request_test(8, 2))
+    @test !any(c.command == "RewriteAsRawString" for c in action_request_test(10, 3))
 
     c = filter(c -> c.command == "RewriteAsRawString", action_request_test(0, 2))[1]
     LanguageServer.workspace_executeCommand_request(LanguageServer.ExecuteCommandParams(missing, c.command, c.arguments), server, server.jr_endpoint)


### PR DESCRIPTION
Was erroring before. Could be allowed, but IMO makes sense to disable that action for docstring strings.