### PR TITLE
Return early in apply missing reference action

### DIFF
--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -310,6 +310,7 @@ function applymissingreffix(x, server, conn)
                     TextEdit(Range(file, offset .+ (0:0)), string(n, "."))
                 ])
                 JSONRPC.send(conn, workspace_applyEdit_request_type, ApplyWorkspaceEditParams(missing, WorkspaceEdit(missing, TextDocumentEdit[tde])))
+                return # TODO: This should probably offer multiple actions instead of just inserting the first hit
             end
         end
     end


### PR DESCRIPTION
In the future it would be better to present multiple actions to the
user, if a symbol exist in multiple modules. As a stopgap this just
returns early and applies the first found module.

Fixes #1087.