### PR TITLE
apply_text_edits: make sure indices are computed with updated document.

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -70,11 +70,6 @@ function set_is_workspace_file(doc::Document, value::Bool)
     doc._workspace_file = value
 end
 
-function applytextdocumentchanges(doc::Document, change)
-    text_document = apply_text_edits(doc._text_document, [change], get_version(doc._text_document))
-    set_text_document!(doc, text_document)
-end
-
 get_offset(doc::Document, line::Integer, character::Integer) = get_offset(doc._text_document, line, character)
 get_offset(doc::Document, p::Position) = get_offset(doc, p.line, p.character)
 get_offset(doc::Document, r::Range) = get_offset(doc, r.start):get_offset(doc, r.stop)

--- a/src/textdocument.jl
+++ b/src/textdocument.jl
@@ -82,6 +82,9 @@ function apply_text_edits(doc::TextDocument, edits, new_version)
             # No range given, replace all text
             content = edit.text
         else
+            # Rebind doc here so that we compute the range for the updated document in
+            # _convert_lsrange_to_jlrange when applying multiple edits
+            doc = TextDocument(doc._uri, content, new_version)
             editrange = _convert_lsrange_to_jlrange(doc, edit.range)
             content = string(content[1:prevind(content, editrange.start)], edit.text, content[nextind(content, editrange.stop):lastindex(content)])
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using LanguageServer:
     Document,
     TextDocument,
     apply_text_edits,
-    applytextdocumentchanges,
     get_text_document,
     set_text_document!,
     get_text,

--- a/test/test_edit.jl
+++ b/test/test_edit.jl
@@ -21,10 +21,10 @@ mktempdir() do dir
             LanguageServer.VersionedTextDocumentIdentifier(get_uri(doc), 5),
             [LanguageServer.TextDocumentContentChangeEvent(LanguageServer.Range(LanguageServer.Position(s1...), LanguageServer.Position(s2...)), 0, insert)]
         )
-        tdcce = params.contentChanges[1]
+        tdcce = params.contentChanges
 
         # TODO: This should only re-parse necessary parts of the document
-        LanguageServer.applytextdocumentchanges(doc, tdcce)
+        LanguageServer.set_text_document!(doc, LanguageServer.apply_text_edits(get_text_document(doc), tdcce, 1))
         LanguageServer.parse_all(doc, server)
 
         new_cst = CSTParser.parse(LanguageServer.get_text(doc), true)


### PR DESCRIPTION
Fixes #1058