### PR TITLE
Simplify JuliaFormatter config search

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -115,27 +115,20 @@ function get_file_loc(x::EXPR, offset=0, c=nothing)
     return nothing, offset
 end
 
-function search_file(filename, dir, topdir)
+function search_file(filename, dir)
     parent_dir = dirname(dir)
-    return if (!startswith(dir, topdir) || parent_dir == dir || isempty(dir))
+    return if (parent_dir == dir || isempty(dir))
         nothing
     else
         path = joinpath(dir, filename)
-        isfile(path) ? path : search_file(filename, parent_dir, topdir)
+        isfile(path) ? path : search_file(filename, parent_dir)
     end
 end
 
 function get_juliaformatter_config(doc, server)
     path = get_path(doc)
-
-    # search through workspace for a `.JuliaFormatter.toml`
-    workspace_dirs = sort(filter(f -> startswith(path, f), collect(server.workspaceFolders)), by = length, rev = true)
-    config_path = length(workspace_dirs) > 0 ?
-        search_file(JuliaFormatter.CONFIG_FILE_NAME, path, workspace_dirs[1]) :
-        nothing
-
+    config_path = search_file(JuliaFormatter.CONFIG_FILE_NAME, path)
     config_path === nothing && return nothing
-
     @debug "Found JuliaFormatter config at $(config_path)"
     return JuliaFormatter.parse_config(config_path)
 end


### PR DESCRIPTION
The previous method of searching for a `.JuliaFormatter.toml` file started in the document's directory, recursing up the filesystem hierarchy until the workspace directory name was not a prefix of the current directory name.

This is problematic because it means that users can no longer have a "global" configuration for all of their Julia projects.

Assume the user has a directory housing all of their Julia projects at `~/Projects/Julia`, and they are currently working on file `~/Projects/Julia/ProjectA/src/ProjectA.jl`. The original behavior would check the following files in order for the presence of a `.JuliaFormatter.toml` file:

- `~/Projects/Julia/ProjectA/src/.JuliaFormatter.toml`
- `~/Projects/Julia/ProjectA/.JuliaFormatter.toml`

However, the user may have actually wanted the algorithm to detect their "global" configuration located at `~/Projects/Julia/.JuliaFormatter.toml`. The previous algorithm would never reach this far up the directory hierarchy, because the base case for terminating the recursion stopped when the workspace directory string (`~/Projects/Julia/ProjectA`) was not a prefix of the currently traversed directory (`~/Projects/Julia`), thus stopping the recursion and returning `nothing`, which forces the loading and parsing of the default configuration.

With this new method, we simply remove the workspace prefix check, simplifying the code in the process. This allows users to place a `.JuliaFormatter.toml` file anywhere up the directory tree from the project they are working on, just as `JuliaFormatter.jl` itself functions.

Fixes #1113 
Fixes #1115
