### PR TITLE
Fixes for organize imports with local modules

### DIFF
--- a/test/requests/actions.jl
+++ b/test/requests/actions.jl
@@ -92,6 +92,10 @@ end
 
     c = filter(c -> c.command == "OrganizeImports", action_request_test(0, 1))[1]
     LanguageServer.workspace_executeCommand_request(LanguageServer.ExecuteCommandParams(missing, c.command, c.arguments), server, server.jr_endpoint)
+
+    settestdoc("using .LocalModule: foo\n")
+    c = filter(c -> c.command == "OrganizeImports", action_request_test(0, 1))[1]
+    LanguageServer.workspace_executeCommand_request(LanguageServer.ExecuteCommandParams(missing, c.command, c.arguments), server, server.jr_endpoint)
 end
 
 @testset "Convert between string and raw strings" begin


### PR DESCRIPTION
This patch contains fixes for the following two errors in in the
organize imports action when used on local modules:

 - `using .Foo` formatted erroneously as `using ..Foo`
 - `using .Foo: bar` tried to format `using ..Foo: bar`, but since this
   is not a valid Julia expression this errored and crashed the language
   server