### PR TITLE
Add isvalid check to find_document_links

### DIFF
--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -94,7 +94,7 @@ end
 
 function find_document_links(x, doc, offset, links)
     if x isa EXPR && CSTParser.isstringliteral(x)
-        if valof(x) isa String && sizeof(valof(x)) < 256 # AUDIT: OK
+        if valof(x) isa String && isvalid(valof(x)) && sizeof(valof(x)) < 256 # AUDIT: OK
             try
                 if isabspath(valof(x)) && safe_isfile(valof(x))
                     path = valof(x)


### PR DESCRIPTION
Should fix this error reported on slack:
```
ERROR: type Nothing has no field captures
Stacktrace:
  [1] getproperty
    @ .\Base.jl:42 [inlined]
  [2] splitdrive(path::String)
    @ Base.Filesystem .\path.jl:39
  [3] joinpath(paths::Tuple{String, String})
    @ Base.Filesystem .\path.jl:269
  [4] joinpath(::String, ::String, ::Vararg{String})
    @ Base.Filesystem .\path.jl:327
  [5] find_document_links(x::CSTParser.EXPR, doc::LanguageServer.Document, offset::Int64, links::Vector{LanguageServer.DocumentLink})
    @ LanguageServer c:\Users\Marcin\.vscode-insiders\extensions\julialang.language-julia-insider-1.6.28\scripts\packages\LanguageServer\src\requests\misc.jl:102
  [6][ Info: Loading InlineStrings from cache... (0%)
 find_document_links(x::CSTParser.EXPR, doc::LanguageServer.Document, offset::Int64, links::Vector{LanguageServer.DocumentLink}) (repeats 2 times)
    @ LanguageServer c:\Users\Marcin\.vscode-insiders\extensions\julialang.language-julia-insider-1.6.28\scripts\packages\LanguageServer\src\requests\misc.jl:113
  [7] textDocument_documentLink_request
    @ c:\Users\Marcin\.vscode-insiders\extensions\julialang.language-julia-insider-1.6.28\scripts\packages\LanguageServer\src\requests\misc.jl:91 [inlined]
  [8] (::LanguageServer.var"#98#99"{typeof(LanguageServer.textDocument_documentLink_request), LanguageServerInstance})(conn::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint, Base.PipeEndpoint}, params::LanguageServer.DocumentLinkParams)
    @ LanguageServer c:\Users\Marcin\.vscode-insiders\extensions\julialang.language-julia-insider-1.6.28\scripts\packages\LanguageServer\src\languageserverinstance.jl:262
  [9] dispatch_msg(x::JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint, Base.PipeEndpoint}, dispatcher::JSONRPC.MsgDispatcher, msg::Dict{String, Any})
    @ JSONRPC c:\Users\Marcin\.vscode-insiders\extensions\julialang.language-julia-insider-1.6.28\scripts\packages\JSONRPC\src\typed.jl:67
 [10] run(server::LanguageServerInstance)
    @ LanguageServer[ Info: Loading Parsers from cache... (0%)
 c:\Users\Marcin\.vscode-insiders\extensions\julialang.language-julia-insider-1.6.28\scripts\packages\LanguageServer\src\languageserverinstance.jl:382
 [11] top-level scope
    @ c:\Users\Marcin\.vscode-insiders\extensions\julialang.language-julia-insider-1.6.28\scripts\languageserver\main.jl:96
```