### PR TITLE
Fix  (julia)markdown parsing

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -70,6 +70,8 @@ function set_is_workspace_file(doc::Document, value::Bool)
     doc._workspace_file = value
 end
 
+get_language_id(doc::Document) = doc._text_document._language_id
+
 get_offset(doc::Document, line::Integer, character::Integer) = get_offset(doc._text_document, line, character)
 get_offset(doc::Document, p::Position) = get_offset(doc, p.line, p.character)
 get_offset(doc::Document, r::Range) = get_offset(doc, r.start):get_offset(doc, r.stop)

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -449,7 +449,7 @@ function julia_getModuleAt_request(params::VersionedTextDocumentPositionParams, 
             return mismatched_version_error(uri, doc, params, "getModuleAt")
         end
     else
-        return nodocuemnt_error(uri)
+        return nodocument_error(uri)
     end
     return "Main"
 end
@@ -467,7 +467,7 @@ end
 
 function julia_getDocAt_request(params::VersionedTextDocumentPositionParams, server::LanguageServerInstance, conn)
     uri = params.textDocument.uri
-    hasdocument(server, uri) || return nodocuemnt_error(uri)
+    hasdocument(server, uri) || return nodocument_error(uri)
 
     doc = getdocument(server, uri)
     env = getenv(doc, server)

--- a/src/requests/misc.jl
+++ b/src/requests/misc.jl
@@ -12,7 +12,7 @@ function julia_getCurrentBlockRange_request(tdpp::VersionedTextDocumentPositionP
     fallback = (Position(0, 0), Position(0, 0), tdpp.position)
     uri = tdpp.textDocument.uri
 
-    hasdocument(server, uri) || return nodocuemnt_error(uri)
+    hasdocument(server, uri) || return nodocument_error(uri)
 
     doc = getdocument(server, uri)
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,7 +1,7 @@
 # VSCode specific
 # ---------------
 
-nodocuemnt_error(uri, data=nothing) =
+nodocument_error(uri, data=nothing) =
     return JSONRPC.JSONRPCError(-32099, "document $(uri) requested but not present in the JLS", data)
 
 function mismatched_version_error(uri, doc, params, msg, data=nothing)


### PR DESCRIPTION
This adds a new _language_id field to TextDocument, which
can be queried downstream. It's important to not look at
line endings here, because the client may set the language
to some arbitrary value which may or may not match
the extension.

An added bonus is that we don't try to parse quite as much 
invalid julia code -- the previous implementation would try to 
parse each markdown file as Julia and then extract Julia code
blocks from that.