### PR TITLE
Add more checks for NULL in strings

### DIFF
--- a/src/juliaworkspace.jl
+++ b/src/juliaworkspace.jl
@@ -70,7 +70,7 @@ function read_textdocument_from_uri(uri::URI)
 
     content = try
         s = read(path, String)
-        (isvalid(s) && !occursin('\0', s)) || return nothing
+        our_isvalid(s) || return nothing
         s
     catch err
         is_walkdir_error(err) || rethrow()

--- a/src/juliaworkspace.jl
+++ b/src/juliaworkspace.jl
@@ -70,7 +70,7 @@ function read_textdocument_from_uri(uri::URI)
 
     content = try
         s = read(path, String)
-        isvalid(s) || return nothing
+        (isvalid(s) && !occursin('\0', s)) || return nothing
         s
     catch err
         is_walkdir_error(err) || rethrow()

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -108,7 +108,7 @@ function load_folder(path::String, server)
                         else
                             content = try
                                 s = read(filepath, String)
-                                (isvalid(s) && !occursin('\0', s)) || continue
+                                our_isvalid(s) || continue
                                 s
                             catch err
                                 is_walkdir_error(err) || rethrow()

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -265,7 +265,7 @@ function search_for_parent(dir::String, file::String, drop=3, parents=String[])
                 # Could be sped up?
                 content = try
                     s = read(filename, String)
-                    (isvalid(s) && !occursin('\0', s)) || continue
+                    our_isvalid(s) || continue
                     s
                 catch err
                     isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
@@ -292,7 +292,7 @@ function is_parentof(parent_path, child_path, server)
     if !hasdocument(server, puri)
         content = try
             s = read(parent_path, String)
-            (isvalid(s) && !occursin('\0', s)) || return false
+            our_isvalid(s) || return false
             s
         catch err
             isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -265,7 +265,7 @@ function search_for_parent(dir::String, file::String, drop=3, parents=String[])
                 # Could be sped up?
                 content = try
                     s = read(filename, String)
-                    isvalid(s) || continue
+                    (isvalid(s) && !occursin('\0', s)) || continue
                     s
                 catch err
                     isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()
@@ -292,7 +292,7 @@ function is_parentof(parent_path, child_path, server)
     if !hasdocument(server, puri)
         content = try
             s = read(parent_path, String)
-            isvalid(s) || return false
+            (isvalid(s) && !occursin('\0', s)) || return false
             s
         catch err
             isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -21,7 +21,7 @@ function workspace_didChangeWatchedFiles_notification(params::DidChangeWatchedFi
                     filepath = uri2filepath(uri)
                     content = try
                         s = read(filepath, String)
-                        if !isvalid(s) || occursin('\0', s)
+                        if !our_isvalid(s)
                             deletedocument!(server, uri)
                             continue
                         end
@@ -40,7 +40,7 @@ function workspace_didChangeWatchedFiles_notification(params::DidChangeWatchedFi
                 filepath = uri2filepath(uri)
                 content = try
                     s = read(filepath, String)
-                    (isvalid(s) && !occursin('\0', s)) || continue
+                    our_isvalid(s) || continue
                     s
                 catch err
                     isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -40,7 +40,7 @@ function workspace_didChangeWatchedFiles_notification(params::DidChangeWatchedFi
                 filepath = uri2filepath(uri)
                 content = try
                     s = read(filepath, String)
-                    isvalid(s) || continue
+                    (isvalid(s) && !occursin('\0', s)) || continue
                     s
                 catch err
                     isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -12,7 +12,7 @@ end
 function loadfile(server::LanguageServerInstance, path::String)
     source = try
         s = read(path, String)
-        (isvalid(s) && !occursin('\0', s)) || return
+        our_isvalid(s) || return
         s
     catch err
         isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()

--- a/src/staticlint.jl
+++ b/src/staticlint.jl
@@ -12,7 +12,7 @@ end
 function loadfile(server::LanguageServerInstance, path::String)
     source = try
         s = read(path, String)
-        isvalid(s) || return
+        (isvalid(s) && !occursin('\0', s)) || return
         s
     catch err
         isa(err, Base.IOError) || isa(err, Base.SystemError) || rethrow()

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -120,6 +120,10 @@ function isvalidjlfile(path)
     endswith(path, ".jl")
 end
 
+function our_isvalid(s)
+    return isvalid(s) && !occursin('\0', s)
+end
+
 function get_expr(x, offset, pos=0, ignorewhitespace=false)
     if pos > offset
         return nothing


### PR DESCRIPTION
Should fix a crash reporting bug, plus I added the same check in all places where we call `isvalid` as that seems what we want.