### PR TITLE
Vendor tryparse for UUIDs pre 1.6

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -421,3 +421,45 @@ function is_in_target_dir_of_package(pkgpath, target)
         return false
     end
 end
+
+@static if VERSION < v"1.6"
+    let
+        @inline function uuid_kernel(s, i, u)
+            _c = UInt32(@inbounds codeunit(s, i))
+            d = __convert_digit(_c, UInt32(16))
+            d >= 16 && return nothing
+            u <<= 4
+            return u | d
+        end
+        
+        function Base.tryparse(::Type{UUID}, s::AbstractString)
+            u = UInt128(0)
+            ncodeunits(s) != 36 && return nothing
+            for i in 1:8
+                u = uuid_kernel(s, i, u)
+                u === nothing && return nothing
+            end
+            @inbounds codeunit(s, 9) == UInt8('-') || return nothing
+            for i in 10:13
+                u = uuid_kernel(s, i, u)
+                u === nothing && return nothing
+            end
+            @inbounds codeunit(s, 14) == UInt8('-') || return nothing
+            for i in 15:18
+                u = uuid_kernel(s, i, u)
+                u === nothing && return nothing
+            end
+            @inbounds codeunit(s, 19) == UInt8('-') || return nothing
+            for i in 20:23
+                u = uuid_kernel(s, i, u)
+                u === nothing && return nothing
+            end
+            @inbounds codeunit(s, 24) == UInt8('-') || return nothing
+            for i in 25:36
+                u = uuid_kernel(s, i, u)
+                u === nothing && return nothing
+            end
+            return Base.UUID(u)
+        end
+    end
+end


### PR DESCRIPTION
Fixes a crash report. `tryparse` for UUIDs was added in Julia 1.6.