### PR TITLE
textDocument/definition: do not return duplicate locations.

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -79,7 +79,7 @@ function textDocument_definition_request(params::TextDocumentPositionParams, ser
         get_definitions(b, tls, getenv(doc, server), locations)
     end
 
-    return locations
+    return unique!(locations)
 end
 
 function descend(x::EXPR, target::EXPR, offset=0)


### PR DESCRIPTION
VS Code seems to filter this in the UI, but that is not happening in neovim so perhaps this should be handled in the UI? But I don't see a reason to return duplicates since they don't contain any other information such as which of the methods on that line they represent etc.