### PR TITLE
Print content directly to stderr instead of using logging

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -46,7 +46,13 @@ function textDocument_didSave_notification(params::DidSaveTextDocumentParams, se
     doc = getdocument(server, uri)
     if params.text isa String
         if get_text(doc) != params.text
-            @error "Mismatch between server and client text" get_text(doc) params.text
+            println(stderr, "Mismatch between server and client text")
+            println(stderr, "========== BEGIN SERVER SIDE TEXT ==========")
+            println(stderr, get_text(doc))
+            println(stderr, "========== END SERVER SIDE TEXT ==========")
+            println(stderr, "========== BEGIN CLIENT SIDE TEXT ==========")
+            println(stderr, params.text)
+            println(stderr, "========== END CLIENT SIDE TEXT ==========")
             JSONRPC.send(conn, window_showMessage_notification_type, ShowMessageParams(MessageTypes.Error, "Julia Extension: Please contact us! Your extension just crashed with a bug that we have been trying to replicate for a long time. You could help the development team a lot by contacting us at https://github.com/julia-vscode/julia-vscode so that we can work together to fix this issue."))
             throw(LSSyncMismatch("Mismatch between server and client text for $(get_uri(doc)). _open_in_editor is $(doc._open_in_editor). _workspace_file is $(doc._workspace_file). _version is $(get_version(doc))."))
         end


### PR DESCRIPTION
Follow up to #1164. Seems difficult to convince the logger not to truncate the string, so print directly to stderr.