### PR TITLE
Use unreserved error codes

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -3,7 +3,7 @@
 
 function nodocument_error(uri, data=nothing)
     return JSONRPC.JSONRPCError(
-        1000,
+        -33100,
         "document $(uri) requested but not present in the JLS",
         data
     )
@@ -11,7 +11,7 @@ end
 
 function mismatched_version_error(uri, doc, params, msg, data=nothing)
     return JSONRPC.JSONRPCError(
-        1001,
+        -33101,
         "version mismatch in $(msg) request for $(uri): JLS $(get_version(doc)), client: $(params.version)",
         data
     )

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,12 +1,17 @@
 # VSCode specific
 # ---------------
 
-nodocument_error(uri, data=nothing) =
-    return JSONRPC.JSONRPCError(-32099, "document $(uri) requested but not present in the JLS", data)
+function nodocument_error(uri, data=nothing)
+    return JSONRPC.JSONRPCError(
+        1000,
+        "document $(uri) requested but not present in the JLS",
+        data
+    )
+end
 
 function mismatched_version_error(uri, doc, params, msg, data=nothing)
     return JSONRPC.JSONRPCError(
-        -32099,
+        1001,
         "version mismatch in $(msg) request for $(uri): JLS $(get_version(doc)), client: $(params.version)",
         data
     )
@@ -440,7 +445,7 @@ end
                 _A <= _c <= _Z ? _c-_A+ UInt32(10) :
                 _a <= _c <= _z ? _c-_a+a           : UInt32(base)
         end
-        
+
         @inline function uuid_kernel(s, i, u)
             _c = UInt32(@inbounds codeunit(s, i))
             d = __convert_digit(_c, UInt32(16))
@@ -448,7 +453,7 @@ end
             u <<= 4
             return u | d
         end
-        
+
         function Base.tryparse(::Type{UUID}, s::AbstractString)
             u = UInt128(0)
             ncodeunits(s) != 36 && return nothing


### PR DESCRIPTION
`-32099` is actually in the reserved range of error codes, and for example is already used by the ls client library that we use in the extension on the Typescript side of things for a different error condition, so one can no longer differentiate between these error conditions on the client side.

This now uses an error code that should be outside any reserved range. Technically we'll need to tag a major version, unless we are very positive that no client other than VS Code is using this functionality?

Also needs a corresponding PR on the extension side.