### PR TITLE
Fix hover on arguments of qualified call

### DIFF
--- a/src/requests/hover.jl
+++ b/src/requests/hover.jl
@@ -267,7 +267,12 @@ function get_fcall_position(x::EXPR, documentation, visited=Set{EXPR}())
                     documentation = string("Datatype field `$(dts.fieldnames[arg_i])`", "\n", documentation)
                 end
             else
-                documentation = string("Argument $arg_i of $(minargs) in call to `", CSTParser.str_value(fname), "`\n", documentation)
+                callname = if CSTParser.is_getfield(fname)
+                    CSTParser.str_value(fname.args[1]) * "." * CSTParser.str_value(CSTParser.get_rhs_of_getfield(fname))
+                else
+                    CSTParser.str_value(fname)
+                end
+                documentation = string("Argument $arg_i of $(minargs) in call to `", callname, "`\n", documentation)
             end
             return documentation
         else

--- a/test/requests/test_hover.jl
+++ b/test/requests/test_hover.jl
@@ -51,7 +51,7 @@ end
 
 @testitem "hover docs" begin
     include("../test_shared_server.jl")
-    
+
     settestdoc("""
     "I have a docstring"
     Base.@kwdef struct SomeStruct
@@ -59,4 +59,16 @@ end
     end
     """)
     @test startswith(hover_test(1, 20).contents.value, "I have a docstring")
+end
+
+@testitem "hover argument qualified function" begin
+    include("../test_shared_server.jl")
+
+    settestdoc("""
+    module M
+        f(a,b,c,d,e) = 1
+    end
+    M.f(1,2,3,4,5)
+    """)
+    @test hover_test(3, 5).contents.value == "Argument 1 of 5 in call to `M.f`\n"
 end


### PR DESCRIPTION
Names of a qualified function calls were not displaying in hover text.

Before  
![image](https://user-images.githubusercontent.com/6343165/198833337-3fc38613-d989-43a0-b00a-020702a9ccba.png)

After  
![image](https://user-images.githubusercontent.com/6343165/198835090-3a38fbdd-875e-4dc4-8286-cde8f289e6f5.png)

