### PR TITLE
Fix range formatting

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -214,7 +214,7 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
     if isnothing(range_formatted)
         return TextEdit[]
     end
-    return TextEdit[TextEdit(Range(params.range.start.line, 0, params.range.stop.line, params.range.stop.character), range_formatted[1])]
+    return TextEdit[TextEdit(Range(params.range.start.line, 0, params.range.stop.line, 99999999), range_formatted[1])]
 end
 
 function find_references(textDocument::TextDocumentIdentifier, position::Position, server)

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -184,10 +184,10 @@ function format_text(text::AbstractString, params, config)
 end
 
 function mark_range(text::AbstractString, startline, stopline, startmark, stopmark)
-  textlines = split(text, "\n")
-  insert!(textlines, startline + 1, startmark)
-  insert!(textlines, stopline + 3, stopmark)
-  return join(textlines, "\n")
+    textlines = split(text, "\n")
+    insert!(textlines, startline + 1, startmark)
+    insert!(textlines, stopline + 3, stopmark)
+    return join(textlines, "\n")
 end
 
 function textDocument_range_formatting_request(params::DocumentRangeFormattingParams, server::LanguageServerInstance, conn)
@@ -197,8 +197,8 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
     oldcontent = get_text(doc)
     startline = params.range.start.line
     stopline = params.range.stop.line
-    startmark =  "#___________START___________"
-    stopmark =   "#___________STOP____________"
+    startmark = "#___________START___________"
+    stopmark = "#___________STOP____________"
     text_marked = mark_range(oldcontent, startline, stopline, startmark, stopmark)
 
     text_formatted = try
@@ -214,9 +214,9 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
 
     range_formatted = match(Regex("$startmark\n((?s).*\n)\\s*$stopmark"), text_formatted)
     if isnothing(range_formatted)
-      newcontent = oldcontent
+        newcontent = oldcontent
     else
-      newcontent = replace(text_marked, Regex("$startmark\n(?s).*$stopmark\n") => range_formatted[1])
+        newcontent = replace(text_marked, Regex("$startmark\n(?s).*$stopmark\n") => range_formatted[1])
     end
     end_l, end_c = get_position_from_offset(doc, sizeof(get_text(doc))) # AUDIT: OK
     lsedits = TextEdit[TextEdit(Range(0, 0, end_l, end_c), newcontent)]

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -195,8 +195,8 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
     oldcontent = get_text(doc)
     startline = params.range.start.line + 1
     stopline = params.range.stop.line + 1
-    startmark = "#؞؞؞؞؞؞؞؞؞LANGUAGESERVER_RANGE_FORMATTING_START؞؞؞؞؞؞؞؞؞"
-    stopmark = "#؞؞؞؞؞؞؞؞؞LANGUAGESERVER_RANGE_FORMATTING_STOP؞؞؞؞؞؞؞؞؞"
+    startmark = "#" * string(uuid4())
+    stopmark = "#" * string(uuid4())
     text_marked = mark_range(oldcontent, startline, stopline, startmark, stopmark)
 
     text_formatted = try

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -191,9 +191,7 @@ function mark_range(text::AbstractString, startline, stopline, startmark, stopma
 end
 
 function textDocument_range_formatting_request(params::DocumentRangeFormattingParams, server::LanguageServerInstance, conn)
-
     doc = getdocument(server, params.textDocument.uri)
-
     oldcontent = get_text(doc)
     startline = params.range.start.line
     stopline = params.range.stop.line

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -214,7 +214,7 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
     if isnothing(range_formatted)
         return TextEdit[]
     end
-    return TextEdit[TextEdit(Range(params.range.start.line, 0, params.range.stop.line, 99999999), range_formatted[1])]
+    return TextEdit[TextEdit(Range(params.range.start.line, 0, params.range.stop.line, params.range.stop.character), range_formatted[1])]
 end
 
 function find_references(textDocument::TextDocumentIdentifier, position::Position, server)

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -210,15 +210,11 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
         )
     end
 
-    range_formatted = match(Regex("$startmark\n((?s).*\n)\\s*$stopmark"), text_formatted)
+    range_formatted = match(Regex("$startmark\n((?s).*)\n\\s*$stopmark"), text_formatted)
     if isnothing(range_formatted)
-        newcontent = oldcontent
-    else
-        newcontent = replace(text_marked, Regex("$startmark\n(?s).*$stopmark\n") => range_formatted[1])
+        return TextEdit[]
     end
-    end_l, end_c = get_position_from_offset(doc, sizeof(get_text(doc))) # AUDIT: OK
-    lsedits = TextEdit[TextEdit(Range(0, 0, end_l, end_c), newcontent)]
-    return lsedits
+    return TextEdit[TextEdit(Range(params.range.start.line, 0, params.range.stop.line, 99999999), range_formatted[1])]
 end
 
 function find_references(textDocument::TextDocumentIdentifier, position::Position, server)

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -195,8 +195,8 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
     oldcontent = get_text(doc)
     startline = params.range.start.line + 1
     stopline = params.range.stop.line + 1
-    startmark = "#___________LANGUAGESERVER_RANGE_FORMATTING_START___________"
-    stopmark = "#___________LANGUAGESERVER_RANGE_FORMATTING_STOP____________"
+    startmark = "#؞؞؞؞؞؞؞؞؞LANGUAGESERVER_RANGE_FORMATTING_START؞؞؞؞؞؞؞؞؞"
+    stopmark = "#؞؞؞؞؞؞؞؞؞LANGUAGESERVER_RANGE_FORMATTING_STOP؞؞؞؞؞؞؞؞؞"
     text_marked = mark_range(oldcontent, startline, stopline, startmark, stopmark)
 
     text_formatted = try

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -213,16 +213,13 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
     end
 
     range_formatted = match(Regex("$startmark\n((?s).*\n)\\s*$stopmark"), text_formatted)
-
     if isnothing(range_formatted)
       newcontent = oldcontent
     else
-      newcontent = replace(text_marked, Regex("$startmark\n(?s).*$stopmark\n") => first(range_formatted))
+      newcontent = replace(text_marked, Regex("$startmark\n(?s).*$stopmark\n") => range_formatted[1])
     end
-
     end_l, end_c = get_position_from_offset(doc, sizeof(get_text(doc))) # AUDIT: OK
     lsedits = TextEdit[TextEdit(Range(0, 0, end_l, end_c), newcontent)]
-
     return lsedits
 end
 

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -185,18 +185,18 @@ end
 
 function mark_range(text::AbstractString, startline, stopline, startmark, stopmark)
     textlines = split(text, "\n")
-    insert!(textlines, startline + 1, startmark)
-    insert!(textlines, stopline + 3, stopmark)
+    insert!(textlines, stopline + 1, stopmark)
+    insert!(textlines, startline, startmark)
     return join(textlines, "\n")
 end
 
 function textDocument_range_formatting_request(params::DocumentRangeFormattingParams, server::LanguageServerInstance, conn)
     doc = getdocument(server, params.textDocument.uri)
     oldcontent = get_text(doc)
-    startline = params.range.start.line
-    stopline = params.range.stop.line
-    startmark = "#___________START___________"
-    stopmark = "#___________STOP____________"
+    startline = params.range.start.line + 1
+    stopline = params.range.stop.line + 1
+    startmark = "#___________LANGUAGESERVER_RANGE_FORMATTING_START___________"
+    stopmark = "#___________LANGUAGESERVER_RANGE_FORMATTING_STOP____________"
     text_marked = mark_range(oldcontent, startline, stopline, startmark, stopmark)
 
     text_formatted = try

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -189,7 +189,6 @@ const FORMAT_MARK_END = "---- END LANGUAGESERVER" * " RANGE FORMATTING ----"
 
 function textDocument_range_formatting_request(params::DocumentRangeFormattingParams, server::LanguageServerInstance, conn)
     doc = getdocument(server, params.textDocument.uri)
-    @info "textDocument_formatting_request" params
     oldcontent = get_text(doc)
     startline = params.range.start.line + 1
     stopline = params.range.stop.line + 1

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -210,8 +210,10 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
         )
     end
 
-    range_formatted = match(Regex("$startmark\n((?s).*)\n\\s*$stopmark"), text_formatted)
-    if isnothing(range_formatted)
+    range_regex = Regex("$startmark\n((?s).*)\n\\s*$stopmark")
+    range_formatted = match(range_regex, text_formatted)
+    range_unformatted = match(range_regex, text_marked)
+    if isnothing(range_formatted) || (range_formatted[1] == range_unformatted[1])
         return TextEdit[]
     end
     return TextEdit[TextEdit(Range(params.range.start.line, 0, params.range.stop.line, 99999999), range_formatted[1])]

--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -204,7 +204,7 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
         format_text(text_marked, params, config)
     catch err
         return JSONRPC.JSONRPCError(
-            -32000,
+            -33000,
             "Failed to format document: $err.",
             nothing
         )

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -200,31 +200,6 @@ function get_expr(x, offset::UnitRange{Int}, pos=0, ignorewhitespace=false)
     end
 end
 
-# full (not only trivia) expr containing rng, modulo whitespace
-function get_inner_expr(x, rng::UnitRange{Int}, pos=0, pos_span = 0)
-    if all(pos .> rng)
-        return nothing
-    end
-    if length(x) > 0 && headof(x) !== :NONSTDIDENTIFIER
-        pos_span′ = pos_span
-        for a in x
-            if a in x.args && all(pos_span′ .< rng .<= (pos + a.fullspan))
-                return get_inner_expr(a, rng, pos, pos_span′)
-            end
-            pos += a.fullspan
-            pos_span′ = pos - (a.fullspan - a.span)
-        end
-    elseif pos == 0
-        return x
-    elseif all(pos_span .< rng .<= (pos + x.fullspan))
-        return x
-    end
-    pos -= x.fullspan
-    if all(pos_span .< rng .<= (pos + x.fullspan))
-        return x
-    end
-end
-
 function get_expr1(x, offset, pos=0)
     if length(x) == 0 || headof(x) === :NONSTDIDENTIFIER
         if pos <= offset <= pos + x.span

--- a/test/requests/test_features.jl
+++ b/test/requests/test_features.jl
@@ -127,8 +127,7 @@ end
         else
             return x
         end
-    end
-    """
+    end"""
 
     doc = settestdoc("""
     map([A,B,C]) do x
@@ -141,17 +140,7 @@ end
     end
     end
     """)
-    @test range_formatting_test(2, 0, 2, 0)[1].newText == """
-    map([A,B,C]) do x
-    if x<0 && iseven(x)
-            return 0
-    elseif x==0
-    return 1
-    else
-    return x
-    end
-    end
-    """
+    @test range_formatting_test(2, 0, 2, 0)[1].newText == """        return 0"""
 
     doc = settestdoc("""
     function add(a,b) a+b end
@@ -159,10 +148,7 @@ end
     function mul(a,b) a*b end
     """)
     @test range_formatting_test(1, 0, 1, 0)[1].newText == """
-    function add(a,b) a+b end
     function sub(a, b)
         a - b
-    end
-    function mul(a,b) a*b end
-    """
+    end"""
 end

--- a/test/requests/test_features.jl
+++ b/test/requests/test_features.jl
@@ -151,4 +151,11 @@ end
     function sub(a, b)
         a - b
     end"""
+
+    doc = settestdoc("""
+    function sub(a, b)
+        a - b
+    end
+    """)
+    @test range_formatting_test(0, 0, 2, 0) == LanguageServer.TextEdit[]
 end

--- a/test/requests/test_features.jl
+++ b/test/requests/test_features.jl
@@ -152,4 +152,17 @@ end
     end
     end
     """
+
+    doc = settestdoc("""
+    function add(a,b) a+b end
+    function sub(a,b) a-b end
+    function mul(a,b) a*b end
+    """)
+    @test range_formatting_test(1, 0, 1, 0)[1].newText == """
+    function add(a,b) a+b end
+    function sub(a, b)
+        a - b
+    end
+    function mul(a,b) a*b end
+    """
 end

--- a/test/requests/test_features.jl
+++ b/test/requests/test_features.jl
@@ -103,3 +103,53 @@ end
     """)
     @test all(item.name in ("a", "b", "func", "::Bar", "::Type{Foo}") for item in LanguageServer.textDocument_documentSymbol_request(LanguageServer.DocumentSymbolParams(LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), missing, missing), server, server.jr_endpoint))
 end
+
+@testitem "range formatting" begin
+    include("../test_shared_server.jl")
+
+    doc = settestdoc("""
+    map([A,B,C]) do x
+    if x<0 && iseven(x)
+    return 0
+    elseif x==0
+    return 1
+    else
+    return x
+    end
+    end
+    """)
+    @test range_formatting_test(0, 0, 8, 0)[1].newText == """
+    map([A, B, C]) do x
+        if x < 0 && iseven(x)
+            return 0
+        elseif x == 0
+            return 1
+        else
+            return x
+        end
+    end
+    """
+
+    doc = settestdoc("""
+    map([A,B,C]) do x
+    if x<0 && iseven(x)
+    return 0
+    elseif x==0
+    return 1
+    else
+    return x
+    end
+    end
+    """)
+    @test range_formatting_test(2, 0, 2, 0)[1].newText == """
+    map([A,B,C]) do x
+    if x<0 && iseven(x)
+            return 0
+    elseif x==0
+    return 1
+    else
+    return x
+    end
+    end
+    """
+end

--- a/test/requests/test_features.jl
+++ b/test/requests/test_features.jl
@@ -127,7 +127,8 @@ end
         else
             return x
         end
-    end"""
+    end
+    """
 
     doc = settestdoc("""
     map([A,B,C]) do x
@@ -140,7 +141,7 @@ end
     end
     end
     """)
-    @test range_formatting_test(2, 0, 2, 0)[1].newText == """        return 0"""
+    @test range_formatting_test(2, 0, 2, 0)[1].newText == "        return 0\n"
 
     doc = settestdoc("""
     function add(a,b) a+b end
@@ -150,7 +151,8 @@ end
     @test range_formatting_test(1, 0, 1, 0)[1].newText == """
     function sub(a, b)
         a - b
-    end"""
+    end
+    """
 
     doc = settestdoc("""
     function sub(a, b)
@@ -158,4 +160,12 @@ end
     end
     """)
     @test range_formatting_test(0, 0, 2, 0) == LanguageServer.TextEdit[]
+
+    # \r\n line endings
+    doc = settestdoc("function foo(a,  b)\r\na - b\r\n end\r\n")
+    @test range_formatting_test(0, 0, 2, 0)[1].newText == "function foo(a, b)\r\n    a - b\r\nend\r\n"
+
+    # no trailing newline
+    doc = settestdoc("function foo(a,  b)\na - b\n end")
+    @test range_formatting_test(0, 0, 2, 0)[1].newText == "function foo(a, b)\n    a - b\nend"
 end

--- a/test/test_shared_init_request.jl
+++ b/test/test_shared_init_request.jl
@@ -1,4 +1,4 @@
-import JSONRPC
+import JSONRPC, LanguageServer
 
 init_request = LanguageServer.InitializeParams(
         9902,

--- a/test/test_shared_server.jl
+++ b/test/test_shared_server.jl
@@ -1,5 +1,6 @@
 import Pkg
 using LanguageServer.URIs2
+using LanguageServer: LanguageServerInstance
 
 include("test_shared_init_request.jl")
 

--- a/test/test_shared_server.jl
+++ b/test/test_shared_server.jl
@@ -19,7 +19,7 @@ def_test(line, char) = LanguageServer.textDocument_definition_request(LanguageSe
 ref_test(line, char) = LanguageServer.textDocument_references_request(LanguageServer.ReferenceParams(LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Position(line, char), missing, missing, LanguageServer.ReferenceContext(true)), server, server.jr_endpoint)
 rename_test(line, char) = LanguageServer.textDocument_rename_request(LanguageServer.RenameParams(LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Position(line, char), missing, "newname"), server, server.jr_endpoint)
 hover_test(line, char) = LanguageServer.textDocument_hover_request(LanguageServer.TextDocumentPositionParams(LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Position(line, char)), server, server.jr_endpoint)
-range_formatting_test(line0, char0, line1, char1) = LanguageServer.textDocument_range_formatting_request( LanguageServer.DocumentRangeFormattingParams( LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Range(LanguageServer.Position(line0, char0), LanguageServer.Position(line1, char1)), LanguageServer.FormattingOptions(4, true, missing, missing, missing)), server, server.jr_endpoint)
+range_formatting_test(line0, char0, line1, char1) = LanguageServer.textDocument_range_formatting_request(LanguageServer.DocumentRangeFormattingParams(LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Range(LanguageServer.Position(line0, char0), LanguageServer.Position(line1, char1)), LanguageServer.FormattingOptions(4, true, missing, missing, missing)), server, server.jr_endpoint)
 
 # TODO Replace this with a proper mock endpoint
 JSONRPC.send(::Nothing, ::Any, ::Any) = nothing

--- a/test/test_shared_server.jl
+++ b/test/test_shared_server.jl
@@ -19,6 +19,7 @@ def_test(line, char) = LanguageServer.textDocument_definition_request(LanguageSe
 ref_test(line, char) = LanguageServer.textDocument_references_request(LanguageServer.ReferenceParams(LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Position(line, char), missing, missing, LanguageServer.ReferenceContext(true)), server, server.jr_endpoint)
 rename_test(line, char) = LanguageServer.textDocument_rename_request(LanguageServer.RenameParams(LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Position(line, char), missing, "newname"), server, server.jr_endpoint)
 hover_test(line, char) = LanguageServer.textDocument_hover_request(LanguageServer.TextDocumentPositionParams(LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Position(line, char)), server, server.jr_endpoint)
+range_formatting_test(line0, char0, line1, char1) = LanguageServer.textDocument_range_formatting_request( LanguageServer.DocumentRangeFormattingParams( LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"), LanguageServer.Range(LanguageServer.Position(line0, char0), LanguageServer.Position(line1, char1)), LanguageServer.FormattingOptions(4, true, missing, missing, missing)), server, server.jr_endpoint)
 
 # TODO Replace this with a proper mock endpoint
 JSONRPC.send(::Nothing, ::Any, ::Any) = nothing


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/1180, https://github.com/julia-vscode/LanguageServer.jl/issues/1187, https://github.com/julia-vscode/LanguageServer.jl/issues/1188, and probably https://github.com/julia-vscode/LanguageServer.jl/issues/1184

Here is the idea:
1. We take as input the entire file and the range that should be formatted.
2. We enclose the given range by injecting two markers in the form of comments to the input file.
3. We format the result of step 2 (entire file with markers) using JuliaFormatter.jl. The output should include the injected markers.
4. We replace the given range in the input file with the code inside the markers of the output of step 3, and return this.

This approach avoids the need of having to deal with EXPRs and formats the given range in the context of the entire file.