### PR TITLE
add check for nothing in init params to support emacs

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -175,7 +175,7 @@ function initialize_request(params::InitializeParams, server::LanguageServerInst
         server.clientcapability_workspace_didChangeConfiguration = true
     end
 
-    if !ismissing(params.initializationOptions)
+    if !ismissing(params.initializationOptions) && params.initializationOptions !== nothing
         server.initialization_options = params.initializationOptions
     end
 


### PR DESCRIPTION
Emacs crashes the language server by sending a null for initialize_request's initializationOptions.

Adding `!== nothing` to the `if` block fixes that.