### PR TITLE
fix: stop parsing and linting toml files

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -435,11 +435,15 @@ function relintserver(server)
         # only do a pass on documents once
         root = getroot(doc)
         if !(root in roots)
-            push!(roots, root)
-            semantic_pass(root)
+            if get_language_id(root) in ("julia", "markdown", "juliamarkdown")
+                push!(roots, root)
+                semantic_pass(root)
+            end
         end
     end
     for doc in documents
-        lint!(doc, server)
+        if get_language_id(doc) in ("julia", "markdown", "juliamarkdown")
+            lint!(doc, server)
+        end
     end
 end

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -91,7 +91,7 @@ function textDocument_didChange_notification(params::DidChangeTextDocumentParams
 
     if get_language_id(doc) in ("markdown", "juliamarkdown")
         parse_all(doc, server)
-    else
+    else get_language_id(doc) == "julia"
         cst0, cst1 = getcst(doc), CSTParser.parse(get_text(doc), true)
         r1, r2, r3 = CSTParser.minimal_reparse(s0, get_text(doc), cst0, cst1, inds = true)
         for i in setdiff(1:length(cst0.args), r1 , r3) # clean meta from deleted expr
@@ -116,10 +116,12 @@ function parse_all(doc::Document, server::LanguageServerInstance)
             ps = CSTParser.ParseState(get_text(doc))
             doc.cst, ps = CSTParser.parse(ps, true)
         end
-        if t > 10
+        if t > 1
             # warn to help debugging in the wild
             @warn "CSTParser took a long time ($(round(Int, t)) seconds) to parse $(repr(getpath(doc)))"
         end
+    else
+        return
     end
     sizeof(get_text(doc)) == getcst(doc).fullspan || @error "CST does not match input string length."
     if headof(doc.cst) === :file


### PR DESCRIPTION
We don't want to sic CSTParser on toml files (or our linter, for that matter), so this PR makes sure to only parse/lint Julia or markdown files.