### PR TITLE
Add Kate editor to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ make use of the Julia Language Server for various code editing features:
 - [Sublime Text](https://github.com/tomv564/LSP)
 - [Kakoune](../../wiki/Kakoune)
 - [Helix](https://uncomfyhalomacro.pl/blog/14/)
+- [Kate](../../wiki/Kate)
 - [Others](https://microsoft.github.io/language-server-protocol/implementors/tools/)
 
 ## Installation and Usage


### PR DESCRIPTION
This PR adds Kate to the list of supported editors. The wiki has already been updated with an entry about how to use it and what to prepare.

NB: The PR ([here](https://invent.kde.org/utilities/kate/-/merge_requests/1324)) has just been merged recently, so it will take a bit of time until most users' Kate installations will have the default settings available to them. In the meantime the setting can be easily added by hand (about which I will add a note to the wiki as well).