### PR TITLE
feat: monitor editor pid for exit

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -65,6 +65,7 @@ mutable struct LanguageServerInstance
     clientInfo::Union{InfoParams,Missing}
     initialization_options::Union{Missing,Dict}
 
+    editor_pid::Union{Nothing,Int}
     shutdown_requested::Bool
 
     workspace::JuliaWorkspace
@@ -100,6 +101,7 @@ mutable struct LanguageServerInstance
             missing,
             missing,
             missing,
+            nothing,
             false,
             JuliaWorkspace()
         )
@@ -289,6 +291,8 @@ function Base.run(server::LanguageServerInstance; timings = [])
     add_timer_message!(did_show_timer, timings, "connection established")
 
     trigger_symbolstore_reload(server)
+
+    poll_editor_pid(server)
 
     @async try
         @debug "LS: Starting client listener task."

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -161,6 +161,7 @@ function initialize_request(params::InitializeParams, server::LanguageServerInst
 
     server.clientCapabilities = params.capabilities
     server.clientInfo = params.clientInfo
+    server.editor_pid = params.processId
 
     if !ismissing(params.capabilities.window) && params.capabilities.window.workDoneProgress
         server.clientcapability_window_workdoneprogress = true

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -534,3 +534,19 @@ function send_startup_time_message(timings)
 
     println(stderr, String(take!(io)))
 end
+
+function poll_editor_pid(server::LanguageServerInstance)
+    if server.editor_pid === nothing
+        return
+    end
+    @info "Monitoring editor process with id $(server.editor_pid)"
+    return @async while !server.shutdown_requested
+        sleep(10)
+
+        # kill -0 $editor_pid
+        r = ccall(:uv_kill, Cint, (Cint, Cint), server.editor_pid, 0)
+        if r != 0
+            exit(1)
+        end
+    end
+end


### PR DESCRIPTION
This isn't used by VS Code afaict, but mentioned in the LSP docs
> To support the case that the editor starting a server crashes an editor should also pass its process id to the server. This allows the server to monitor the editor process and to shutdown itself if the editor process dies. 