### PR TITLE
Add better support for SPDX headers

### DIFF
--- a/src/requests/actions.jl
+++ b/src/requests/actions.jl
@@ -350,7 +350,9 @@ function double_to_triple_equal(x, _, conn)
 end
 
 function get_spdx_header(doc::Document)
-    m = match(r"(*ANYCRLF)^# SPDX-License-Identifier:\h+((?:[\w\.-]+)(?:\h+[\w\.-]+)*)\h*$", get_text(doc))
+    # note the multiline flag - without that, we'd try to match the end of the _document_
+    # instead of the end of the line.
+    m = match(r"(*ANYCRLF)^# SPDX-License-Identifier:\h+((?:[\w\.-]+)(?:\h+[\w\.-]+)*)\h*$"m, get_text(doc))
     return m === nothing ? m : String(m[1])
 end
 
@@ -377,7 +379,11 @@ function identify_short_identifier(server::LanguageServerInstance, file::Documen
     end
     if length(candidate_identifiers) == 1
         return first(candidate_identifiers)
+    else
+        numerous = iszero(length(candidate_identifiers)) ? "no" : "multiple"
+        @warn "Found $numerous candidates for the SPDX header from open files, falling back to LICENSE" Candidates=candidate_identifiers
     end
+
     # Fallback to looking for a license file in the same workspace folder
     candidate_files = String[]
     for dir in server.workspaceFolders
@@ -387,21 +393,36 @@ function identify_short_identifier(server::LanguageServerInstance, file::Documen
             end
         end
     end
-    length(candidate_files) == 1 || return nothing
-    license = read(first(candidate_files), String)
+
+    num_candidates = length(candidate_files)
+    if num_candidates != 1
+        iszero(num_candidates) && @warn "No candidate for licenses found, can't add identifier!"
+        num_candidates > 1 && @warn "More than one candidate for licenses found, choose licensing manually!"
+        return nothing
+    end
 
     # This is just a heuristic, but should be OK since this is not something automated, and
     # the programmer will see directly if the wrong license is added.
-    # TODO: Add more licenses...
-    if contains(license, r"MIT\s+(\"?Expat\"?\s+)?License")
+    license_text = read(first(candidate_files), String)
+
+    # Some known different spellings of some licences
+    if contains(license_text, r"^\s*MIT\s+(\"?Expat\"?\s+)?Licen[sc]e")
         return "MIT"
+    elseif contains(license_text, r"^\s*EUROPEAN\s+UNION\s+PUBLIC\s+LICEN[CS]E\s+v\."i)
+        # the first version should be the EUPL version
+        version = match(r"\d\.\d", license_text).match
+        return "EUPL-$version"
     end
+
+    @warn "A license was found, but could not be identified! Consider adding its licence identifier once to a file manually so that LanguageServer.jl can find it automatically next time." Location=first(candidate_files)
     return nothing
 end
 
 function add_license_header(x, server::LanguageServerInstance, conn)
     file, _ = get_file_loc(x)
+    # does the current file already have a header?
     get_spdx_header(file) === nothing || return # TODO: Would be nice to check this already before offering the action
+    # no, so try to find one
     short_identifier = identify_short_identifier(server, file)
     short_identifier === nothing && return
     tde = TextDocumentEdit(VersionedTextDocumentIdentifier(get_uri(file), get_version(file)), TextEdit[


### PR DESCRIPTION
This commit does these things:

 * Add rudimentary detection of EUPL-* licenses
 * Add logging statements throughout the action to make it debuggable should some license not be properly detected
 * Fix a bug with SPDX header detection in existing files

To expand on the last point - previously, the header detection didn't have multiline matching enabled on its regex, which meant that any file having any lines other than the SPDX header wasn't detected as actually having a header. That's a bit bad, since presumably there would be actual source code following that header.

For a visual example, before:

![image](https://github.com/julia-vscode/LanguageServer.jl/assets/11753998/ee86532e-706f-4df1-9bb8-fd7dba643d8d)

After:

![image](https://github.com/julia-vscode/LanguageServer.jl/assets/11753998/ac964985-9275-4c17-b43f-cef3d355b23f)


As for tests - I looked at `test/requests/test_actions.jl` and found an extremely minimal test for that action. I have no idea how to add a test for the functionality there, so I'd appreciate any guidance you can offer.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
