### PR TITLE
fix: disable type hints by default

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -88,7 +88,7 @@ mutable struct LanguageServerInstance
             LINT_DIABLED_DIRS,
             :qualify, # options: :import or :qualify, anything else turns this off
             true,
-            true,
+            false,
             :literals,
             Channel{Any}(Inf),
             err_handler,

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -87,8 +87,8 @@ mutable struct LanguageServerInstance
             :all,
             LINT_DIABLED_DIRS,
             :qualify, # options: :import or :qualify, anything else turns this off
-            true,
             false,
+            true,
             :literals,
             Channel{Any}(Inf),
             err_handler,


### PR DESCRIPTION
Fixes #.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
