### PR TITLE
Add ignoredDirs option to linter

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -42,6 +42,7 @@ mutable struct LanguageServerInstance
     lint_options::StaticLint.LintOptions
     lint_missingrefs::Symbol
     lint_disableddirs::Vector{String}
+    lint_ignoreddirs::Vector{String}
     completion_mode::Symbol
     inlay_hints::Bool
     inlay_hints_variable_types::Bool
@@ -85,7 +86,8 @@ mutable struct LanguageServerInstance
             true,
             StaticLint.LintOptions(),
             :all,
-            LINT_DIABLED_DIRS,
+            LINT_DISABLED_DIRS,
+            LINT_IGNORED_DIRS,
             :qualify, # options: :import or :qualify, anything else turns this off
             false,
             true,

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -99,6 +99,9 @@ function load_folder(path::String, server)
     if load_rootpath(path)
         try
             for (root, _, files) in walkdir(path, onerror=x -> x)
+                if any(occursin.(Regex.(joinpath.(Ref(path), server.lint_ignoreddirs)), Ref(root)))
+                    continue
+                end
                 for file in files
                     filepath = joinpath(root, file)
                     if isvalidjlfile(filepath)
@@ -196,6 +199,8 @@ function initialized_notification(params::InitializedParams, server::LanguageSer
         )
     end
 
+    request_julia_config(server, conn)
+
     if server.workspaceFolders !== nothing
         server.workspace = JuliaWorkspace(Set(filepath2uri.(server.workspaceFolders)))
 
@@ -211,8 +216,6 @@ function initialized_notification(params::InitializedParams, server::LanguageSer
             load_folder(wkspc, server)
         end
     end
-
-    request_julia_config(server, conn)
 
     if server.number_of_outstanding_symserver_requests > 0
         create_symserver_progress_ui(server)


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/3495
Fixes https://github.com/julia-vscode/julia-vscode/issues/1711
Fixes https://github.com/julia-vscode/julia-vscode/issues/797

Adds the `julia.lint.ignoredDirs` option, which takes a list of regex expression. Matching paths will completely ignored by the linter. The default is set to `["\\..*"]`, which will ignore all hidden (starting with a ., like .git) folders.

I have moved the `request_julia_config` earlier, so the user configuration (and not the server defaults) are used in `load_folder`.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
