### PR TITLE
typo fix which sometimes causes lsp to crash

### DIFF
--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -178,7 +178,7 @@ function workspace_didChangeWorkspaceFolders_notification(params::DidChangeWorks
         load_folder(wksp, server)
 
 
-        files = JuliaWorkspaces.read_path_into_textdocuments(ksp.uri)
+        files = JuliaWorkspaces.read_path_into_textdocuments(wksp.uri)
 
         for i in files
             if !haskey(server._open_file_versions, i.uri)


### PR DESCRIPTION
Fixes #.

lsp crashed and checked logs i found UndefVarErrors for `ksp` , guessing this is a typo.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
