### PR TITLE
Use watch files client capability

### DIFF
--- a/src/protocol/configuration.jl
+++ b/src/protocol/configuration.jl
@@ -49,8 +49,17 @@ end
     changes::Vector{FileEvent}
 end
 
+const Pattern = String
+
+struct RelativePattern <: Outbound
+	baseUri::Union{WorkspaceFolder,URI}
+	pattern::Pattern
+end
+
+const GlobPattern = Union{Pattern,RelativePattern}
+
 struct FileSystemWatcher <: Outbound
-    globPattern::String
+    globPattern::GlobPattern
     kind::Union{WatchKind,Missing}
 end
 

--- a/src/protocol/initialize.jl
+++ b/src/protocol/initialize.jl
@@ -23,6 +23,7 @@ end
 
 @dict_readable struct DidChangeWatchedFilesClientCapabilities <: Outbound
     dynamicRegistration::Union{Bool,Missing}
+    relativePatternSupport::Union{Bool,Missing}
 end
 
 @dict_readable struct WorkspaceClientCapabilities <: Outbound

--- a/test/test_shared_init_request.jl
+++ b/test/test_shared_init_request.jl
@@ -11,7 +11,7 @@ init_request = LanguageServer.InitializeParams(
                 true,
                 LanguageServer.WorkspaceEditClientCapabilities(true, missing, missing),
                 LanguageServer.DidChangeConfigurationClientCapabilities(false),
-                LanguageServer.DidChangeWatchedFilesClientCapabilities(false,),
+                LanguageServer.DidChangeWatchedFilesClientCapabilities(false,false),
                 LanguageServer.WorkspaceSymbolClientCapabilities(true, missing),
                 LanguageServer.ExecuteCommandClientCapabilities(true),
                 missing,


### PR DESCRIPTION
Down the road we can expand that to also watch files outside of the workspace, which actually works now.