### PR TITLE
Exclude exact matches from user defined identifier completions

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -259,7 +259,7 @@ function collect_completions(x::StaticLint.Scope, spartial, state::CompletionSta
         possible_names = String[]
         for n in x.names
             resize!(possible_names, 0)
-            if is_completion_match(n[1], spartial)
+            if is_completion_match(n[1], spartial) && n[1] != spartial
                 push!(possible_names, n[1])
             end
             if (nn = string_macro_altname(n[1]); nn !== nothing) && is_completion_match(nn, spartial)


### PR DESCRIPTION
This PR is a suggestion to implement and close #1282.

I have used this locally for a while and did not experience any drawbacks.

Regarding this comment from https://github.com/julia-vscode/LanguageServer.jl/issues/1282#issuecomment-2096217145

> This is an ok solution for the symptom, but imho the more correct fix here is to not offer the current binding. Otherwise you wouldn't get these somewhat useful completions:

It seems that this is not the case, i.e. functions from Base and also from other imported/used packages are still suggested, even when they match exactly. This is regardless whether the module name is prepended (e.g. `Base.sin`) or not (`sin`). Apparently those completions are added in a different code path. For the `Base.sin` example probably in https://github.com/julia-vscode/LanguageServer.jl/blob/e04b51c56c2c4c604b863e35d50a8e5232756264/src/requests/completions.jl#L71-L74

In my tests only exact user defined identifiers are excluded from the completions with this PR, for example if you type
```julia
function foobar() end

function foob|
```
where `|` is the current cursor position, then `foobar` is still suggested. But when you have only typed
```julia
function foobar|
```
or
```julia
function foobar() end

function foobar|
```
then the `foobar` completion (which now is a no-op) is not suggested anymore.