### PR TITLE
Show warnings when a request is slow

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -444,6 +444,13 @@ function Base.run(server::LanguageServerInstance; timings = [])
             JSONRPC.dispatch_msg(server.jr_endpoint, msg_dispatcher, msg)
             toc = time_ns()
             duration = (toc - tic) / 1e+6
+            if 1e-3duration > 1
+                req = msg["method"]
+                if req != "initialize" && req != "initialized" # these requests will certainly take a bit, so don't want on them
+                    @warn "Request $req took a long time ($(round(Int, duration)) ms)."
+                end
+            end
+
 
             if server._send_request_metrics
                 JSONRPC.send(


### PR DESCRIPTION
As discussed @davidanthoff , this outputs a warning when the duration of a request exceeds 1 second. I put the warning here instead of `request_wapper` so that the request name has a better formatting.

- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
