### PR TITLE
Add option "useFormatterConfigDefaults" to make it search upwards for .JuliaFormatter.toml and also in home dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ if there is no parent project.
 ## Development of the VSCode extension
 
 See https://github.com/julia-vscode/julia-vscode/wiki for information on how to test this package with the VSCode extension
+
+## LanguageServer.jl does not normally search upwards for .JuliaFormatter.toml
+You can turn this on by setting the initialization option "useFormatterConfigDefaults" to true

--- a/src/LanguageServer.jl
+++ b/src/LanguageServer.jl
@@ -15,6 +15,8 @@ import Dates
 
 export LanguageServerInstance, runserver
 
+const INIT_OPT_USE_FORMATTER_CONFIG_DEFAULTS = "useFormatterConfigDefaults"
+
 const g_operationId = Ref{String}("")
 
 JSON.lower(uri::URI) = string(uri)


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/3560

Add option "useFormatterConfigDefaults" to make it search upwards for .JuliaFormatter.toml and also in home dir.

If the option is not `true`, it keeps the current behavior.