### PR TITLE
Send `WorkDoneProgressEnd` after `SymbolServer.getstore` reaches 100%

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -235,7 +235,6 @@ function trigger_symbolstore_reload(server::LanguageServerInstance)
                         ProgressParams(server.current_symserver_progress_token, WorkDoneProgressReport(missing, msg, percentage))
                     )
                     if percentage == 100
-                        sleep(10) # give the UI some time to show the end of the progress
                         JSONRPC.send(
                             server.jr_endpoint,
                             progress_notification_type,

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -232,8 +232,16 @@ function trigger_symbolstore_reload(server::LanguageServerInstance)
                     JSONRPC.send(
                         server.jr_endpoint,
                         progress_notification_type,
-                        ProgressParams(server.current_symserver_progress_token, WorkDoneProgressReport(missing, msg, missing))
+                        ProgressParams(server.current_symserver_progress_token, WorkDoneProgressReport(missing, msg, percentage))
                     )
+                    if percentage == 100
+                        sleep(10) # give the UI some time to show the end of the progress
+                        JSONRPC.send(
+                            server.jr_endpoint,
+                            progress_notification_type,
+                            ProgressParams(server.current_symserver_progress_token, WorkDoneProgressEnd(missing))
+                        )
+                    end
                 end
                 @info msg
             end,


### PR DESCRIPTION
Fixes julia-vscode/julia-vscode#3721

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
