### PR TITLE
Avoid errors in empty files

### DIFF
--- a/src/requests/completions.jl
+++ b/src/requests/completions.jl
@@ -504,6 +504,8 @@ function import_completions(ppt, pt, t, is_at_end, x, state::CompletionState)
     end
 end
 
+
+
 function get_preexisting_using_stmts(x::EXPR, doc::Document)
     using_stmts = Dict{String,Any}()
     tls = StaticLint.retrieve_toplevel_scope(x)


### PR DESCRIPTION
This commit adds a method to handle the case where the input file is empty. In this case, the expression object is `nothing`. Without adding this method, an error was thrown.

Closes #1350