### PR TITLE
Update README.md - link to helix-wiki entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ make use of the Julia Language Server for various code editing features:
 - [Emacs](../../wiki/Emacs)
 - [Sublime Text](https://github.com/tomv564/LSP)
 - [Kakoune](../../wiki/Kakoune)
-- [Helix](https://uncomfyhalomacro.pl/blog/14/)
+- [Helix](../../wiki/helix)
 - [Kate](../../wiki/Kate)
 - [Others](https://microsoft.github.io/language-server-protocol/implementors/tools/)
 


### PR DESCRIPTION
The Helix link now points to this repo's wiki entry instead of the pretty old blog post. However, I did not check whether the wiki setup is up to date (but that should be then check and fixed separately)