### PR TITLE
fix: prevent server crash on out-of-range inlayHint range

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -171,8 +171,11 @@ function textDocument_inlayHint_request(params::InlayHintParams, server::Languag
     uri = params.textDocument.uri
     st = jw_source_text(server, uri)
 
-    start_index = index_at(st, params.range.start)
-    end_index = index_at(st, params.range.stop)
+    # Clients can request hints for a range that extends past the current
+    # document (e.g. a sync race between an edit and the request), so index in
+    # forgiving mode to clamp out-of-range positions instead of crashing.
+    start_index = index_at(st, params.range.start, true)
+    end_index = index_at(st, params.range.stop, true)
 
     config = JuliaWorkspaces.InlayHintConfig(
         server.inlay_hints,

--- a/test/requests/test_request_handling.jl
+++ b/test/requests/test_request_handling.jl
@@ -19,6 +19,25 @@
     @test result isa LanguageServer.JSONRPC.JSONRPCError
 end
 
+@testitem "inlayHint request with out-of-range position does not crash the server" setup=[TestSetup, SharedServer] begin
+    server.inlay_hints = true
+    settestdoc("for\nx\ny\nz")
+
+    # A range whose stop position points past the last line of the document
+    # (e.g. a sync race between a snippet insertion and the inlayHint request).
+    # This must produce a graceful result, not an uncaught exception that
+    # unwinds the dispatch loop and kills the server.
+    params = LanguageServer.InlayHintParams(
+        LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"),
+        LanguageServer.Range(LanguageServer.Position(0, 0), LanguageServer.Position(99, 0)),
+        missing,
+    )
+    result = LanguageServer.textDocument_inlayHint_request(params, server, server.jr_endpoint)
+    @test result === nothing || result isa Vector{LanguageServer.InlayHint}
+
+    closetestdoc()
+end
+
 @testitem "editor pid monitoring (#1379)" setup=[TestSetup, SharedServer] begin
     # No editor pid known → no monitor task.
     server.editor_pid = nothing


### PR DESCRIPTION
Index the requested range in forgiving mode so positions past the end of the document are clamped instead of throwing an uncaught `LSOffsetError`, which otherwise unwinds the dispatch loop and kills the server.

Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/1275.