### PR TITLE
fix: clamp out-of-bounds diagnostic ranges instead of crashing the request

### DIFF
--- a/src/textdocument.jl
+++ b/src/textdocument.jl
@@ -147,9 +147,16 @@ Converts a 1-based half-open byte range (as produced by JuliaWorkspaces
 diagnostics and test items) to an LSP Range with UTF-16 character
 encoding. `first(rng)` is the 1-based inclusive start byte and `last(rng)`
 is the 1-based exclusive end.
+
+Offsets are clamped to the document's byte length: a diagnostic or test-item
+range may be computed against a slightly newer/older revision of the content
+than the `SourceText` passed here (the analysis result and the document can
+race), and an out-of-bounds offset must degrade to the document end rather than
+crash the whole request via `get_position_from_offset`.
 """
 function Range(st::JuliaWorkspaces.SourceText, rng::UnitRange)
-    start_l, start_c = get_position_from_offset(st, first(rng) - 1)
-    end_l, end_c = get_position_from_offset(st, last(rng) - 1)
+    n = sizeof(st.content)
+    start_l, start_c = get_position_from_offset(st, clamp(first(rng) - 1, 0, n))
+    end_l, end_c = get_position_from_offset(st, clamp(last(rng) - 1, 0, n))
     return Range(start_l, start_c, end_l, end_c)
 end

--- a/test/requests/test_textdocument.jl
+++ b/test/requests/test_textdocument.jl
@@ -17,6 +17,27 @@
     @test !isopen(uri"untitled:none")
 end
 
+@testitem "Range: an out-of-bounds byte range clamps to EOF instead of crashing" begin
+    using JuliaWorkspaces: SourceText
+
+    st = SourceText("abc\ndef\n", "julia")
+    n = sizeof(st.content)  # 8
+    eof = LanguageServer.get_position_from_offset(st, n)
+
+    # A diagnostic/test-item range can be computed against a newer/older revision
+    # than the current content (the analysis result and the document race). An
+    # exclusive end past EOF must degrade to the document end, not throw
+    # LSPositionToOffsetException and crash the whole request.
+    r = LanguageServer.Range(st, (n + 1):(n + 3))
+    @test r.stop.line == eof[1]
+    @test r.stop.character == eof[2]
+
+    # An in-bounds range is unaffected.
+    r2 = LanguageServer.Range(st, 1:4)
+    @test r2.start == LanguageServer.Position(0, 0)
+    @test r2.stop == LanguageServer.Position(0, 3)
+end
+
 @testitem "TextDocument didSave sync mismatch (#1390)" setup=[TestSetup, SharedServer] begin
     u = uri"untitled:synctest"
     LanguageServer.textDocument_didOpen_notification(LanguageServer.DidOpenTextDocumentParams(LanguageServer.TextDocumentItem(u, "julia", 0, "x = 1")), server, nothing)


### PR DESCRIPTION
`textDocument/diagnostic` builds LSP ranges by converting each JuliaWorkspaces diagnostic's byte range against the current document text, fetched separately from the diagnostics. When an edit shortens the file between those two reads, a diagnostic byte range can exceed the current content length, and `get_position_from_offset` threw `LSPositionToOffsetException` — which propagated out of the request handler and out of `run`, killing the server.

Clamp both offsets to the document's byte length in `Range(st, rng)` (the single conversion boundary for diagnostics and test items) so a stale/racy range degrades to the document end rather than crashing the request.