### PR TITLE
feat: settings for indexing concurrency and workspace-env resolution

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -57,6 +57,8 @@ mutable struct LanguageServerInstance
     symbolcache_download::Bool
     symbolcache_upstream::String
     enable_dynamic_indexing::Bool
+    max_concurrent_indexing_processes::Int
+    enable_workspace_environment_resolution::Bool
 
     clientcapability_workspace_diagnostic_refreshsupport::Bool
 
@@ -102,6 +104,8 @@ mutable struct LanguageServerInstance
             symserver_store_path,
             false,
             "",
+            true,
+            4,
             true,
             false,
             Dict{URI,Int}(),

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -253,6 +253,8 @@ function initialized_notification(params::InitializedParams, server::LanguageSer
             ConfigurationItem(missing, "julia.symbolCacheDownload"),
             ConfigurationItem(missing, "julia.symbolserverUpstream"),
             ConfigurationItem(missing, "julia.enableDynamicIndexing"),
+            ConfigurationItem(missing, "julia.maxConcurrentIndexingProcesses"),
+            ConfigurationItem(missing, "julia.enableWorkspaceEnvironmentResolution"),
         ]))
 
         server.completion_mode = Symbol(something(response[1], :import))
@@ -266,6 +268,8 @@ function initialized_notification(params::InitializedParams, server::LanguageSer
         server.symbolcache_download = something(response[6], false)
         server.symbolcache_upstream = something(response[7], JuliaWorkspaces.DEFAULT_SYMBOLCACHE_UPSTREAM)
         server.enable_dynamic_indexing = something(response[8], true)
+        server.max_concurrent_indexing_processes = something(response[9], 4)
+        server.enable_workspace_environment_resolution = something(response[10], true)
     end
 
     # Construct JuliaWorkspace now that configuration values are available.
@@ -280,7 +284,9 @@ function initialized_notification(params::InitializedParams, server::LanguageSer
         symbolcache_download=server.symbolcache_download,
         symbolcache_upstream=server.symbolcache_upstream,
         indirect_file_watch_callback=indirect_cb,
-        progress_callback=progress_cb
+        progress_callback=progress_cb,
+        max_concurrent_djps=server.max_concurrent_indexing_processes,
+        resolve_workspace_environments=server.enable_workspace_environment_resolution,
     )
 
     marked_versions = TraceLogging.@trace mark_current_diagnostics_testitems(server.workspace)

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -93,6 +93,8 @@ function request_julia_config(server::LanguageServerInstance, conn)
         ConfigurationItem(missing, "julia.symbolCacheDownload"),
         ConfigurationItem(missing, "julia.symbolserverUpstream"),
         ConfigurationItem(missing, "julia.enableDynamicIndexing"),
+        ConfigurationItem(missing, "julia.maxConcurrentIndexingProcesses"),
+        ConfigurationItem(missing, "julia.enableWorkspaceEnvironmentResolution"),
     ]))
 
     new_completion_mode = Symbol(something(response[1], :import))
@@ -115,6 +117,8 @@ function request_julia_config(server::LanguageServerInstance, conn)
     server.symbolcache_download = something(response[6], false)
     server.symbolcache_upstream = something(response[7], JuliaWorkspaces.DEFAULT_SYMBOLCACHE_UPSTREAM)
     server.enable_dynamic_indexing = something(response[8], true)
+    server.max_concurrent_indexing_processes = something(response[9], 4)
+    server.enable_workspace_environment_resolution = something(response[10], true)
 end
 
 function gc_files_from_workspace(server::LanguageServerInstance)


### PR DESCRIPTION
`julia.maxConcurrentIndexingProcesses` caps concurrent dynamic indexing child processes (0 = unlimited); `julia.enableWorkspaceEnvironmentResolution = false` disables standalone-project/test-environment fabrication.
