### PR TITLE
fix: clamp out-of-range byte offsets instead of failing the request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md for JuliaWorkspaces.jl
+
+This is a static analysis engine for Julia projects and mainly backs LanguageServer.jl.
+
+- Use `julia-mcp` in a new synthetic Julia environment.
+    - Make sure Revise is loaded before this package
+    - Use an environment that `Pkg.develop`s this package and adds TestItemRunner
+    - Restart the session when unexpected failures occur (due to accumulation of state) or when making changes to structs/`@derived` functions
+- Always run tests first via `TestItemRunner`
+- For checkpointing/final validation, run tests in a new process with `Pkg.test()`
+- Fix any test or type errors until the whole suite is green.
+- Add or update tests for the code you change, even if nobody asked.
+- Keep code comments brief and to-the-point. Don't reference random non-representative examples
+- Build a fresh `JuliaWorkspace` per check; Revise picks up non-`@derived` edits but memoized results are stale.

--- a/src/textdocument.jl
+++ b/src/textdocument.jl
@@ -112,7 +112,15 @@ byte offset. Handles UTF-16 encoding for LSP compliance.
 function get_position_from_offset(st::JuliaWorkspaces.SourceText, offset::Integer)
     text = st.content
     line_indices = st.line_indices
-    offset > sizeof(text) && throw(LSPositionToOffsetException("offset[$offset] > sizeof(content)[$(sizeof(text))]"))
+
+    # A stale/out-of-bounds offset (e.g. a diagnostic or test-item range that
+    # lags a content edit) must not fail the whole request: clamp it to the
+    # document and warn so the underlying inconsistency stays visible.
+    n = sizeof(text)
+    if offset < 0 || offset > n
+        @warn "Clamping out-of-range byte offset to document bounds" offset content_size = n
+        offset = clamp(offset, 0, n)
+    end
 
     # Find which line contains the offset (line_indices are 1-based byte positions)
     # Convert offset (0-based) to 1-based index for comparison

--- a/test/test_offset_clamp.jl
+++ b/test/test_offset_clamp.jl
@@ -1,0 +1,22 @@
+@testitem "Range conversion clamps out-of-bounds offsets and warns" begin
+    import JuliaWorkspaces, Logging
+    using JuliaWorkspaces: SourceText
+    using LanguageServer: Range, get_position_from_offset
+
+    content = "abc\ndef\n"   # 8 bytes
+    st = SourceText(content, "julia")
+    n = sizeof(content)
+
+    # In-bounds range converts normally, with no warning.
+    r_ok = @test_logs min_level = Logging.Warn Range(st, 1:4)
+    @test r_ok isa Range
+
+    # A stale range whose exclusive end is past EOF (e.g. diagnostics lagging a
+    # content edit): the start offset first(rng)-1 = 9 exceeds sizeof = 8. It
+    # must clamp to the document end and warn, not throw and fail the request.
+    r = @test_logs (:warn,) match_mode = :any Range(st, 10:9)
+    @test r isa Range
+
+    eof_line, eof_char = get_position_from_offset(st, n)
+    @test (r.start.line, r.start.character) == (eof_line, eof_char)
+end


### PR DESCRIPTION
A stale or out-of-bounds offset (e.g. a diagnostic or test-item range that lags a content edit) no longer throws and fails the whole request. It is clamped to the document bounds and a warning is emitted so the underlying inconsistency stays visible.

Adds a test covering the clamp/warn behavior and an AGENTS.md with JuliaWorkspaces development guidance.
