### PR TITLE
feat(diagnostics): suppress diagnostics for files outside the workspace

### DIFF
--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -112,7 +112,7 @@ end
 
 function textDocument_diagnostic_request(params::DocumentDiagnosticParams, server::LanguageServerInstance, conn)
     uri = params.textDocument.uri
-    jw_diags = JuliaWorkspaces.has_file(server.workspace, uri) ?
+    jw_diags = (is_workspace_file(server, uri) && JuliaWorkspaces.has_file(server.workspace, uri)) ?
         JuliaWorkspaces.get_diagnostic(server.workspace, uri) : []
     result_id = string(hash(jw_diags))
 

--- a/src/requests/workspace.jl
+++ b/src/requests/workspace.jl
@@ -185,6 +185,7 @@ function workspace_diagnostic_request(params::WorkspaceDiagnosticParams, server:
     items = Union{WorkspaceFullDocumentDiagnosticReport,WorkspaceUnchangedDocumentDiagnosticReport}[]
 
     for (uri, _) in JuliaWorkspaces.get_diagnostics(server.workspace)
+        is_workspace_file(server, uri) || continue
         diags = JuliaWorkspaces.get_diagnostic(server.workspace, uri)
         result_id = string(hash(diags))
         version = get(server._open_file_versions, uri, missing)

--- a/src/testitem_diagnostic_marking.jl
+++ b/src/testitem_diagnostic_marking.jl
@@ -95,6 +95,7 @@ function publish_diagnostics(server, jw_diagnostics_updated, jw_diagnostics_dele
     diagnostics = Dict{URI,Vector{Diagnostic}}()
 
     for uri in all_uris_with_updates
+        is_workspace_file(server, uri) || continue
         new_diags = JuliaWorkspaces.has_file(server.workspace, uri) ?
             JuliaWorkspaces.get_diagnostic(server.workspace, uri) : []
         diagnostics[uri] = build_lsp_diagnostics(server, uri, new_diags)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -20,6 +20,12 @@ end
 # misc
 # ----
 
+# A file is only eligible for diagnostics if it lives inside a workspace folder.
+# Files opened outside the workspace are still tracked in JuliaWorkspaces (so
+# cross-file resolution works) but are kept out of `_workspace_files`; a complete
+# analysis of them is impossible, so we never emit diagnostics for them.
+is_workspace_file(server, uri) = uri in server._workspace_files
+
 # TODO I believe this will also remove files from documents that were added
 # not because they are part of the workspace, but by either StaticLint or
 # the include follow logic.

--- a/test/test_out_of_workspace_diagnostics.jl
+++ b/test/test_out_of_workspace_diagnostics.jl
@@ -1,0 +1,86 @@
+@testitem "Diagnostics: none emitted for files outside workspace folders" begin
+    import Pkg
+    import LanguageServer
+    using LanguageServer.URIs2
+    using LanguageServer: LanguageServerInstance
+    import JuliaWorkspaces
+    import JSONRPC, JSON
+
+    # A real endpoint marked "running" but with no writer task: `send` just
+    # enqueues serialized messages onto `out_msg_queue`, which we drain and
+    # inspect to see what would have been published to the client.
+    endpoint = JSONRPC.JSONRPCEndpoint(Base.BufferStream(), Base.BufferStream())
+    endpoint.status = JSONRPC.status_running
+
+    function drain_published(endpoint)
+        published = Dict{String,Any}()
+        while isready(endpoint.out_msg_queue)
+            msg = JSON.parse(String(take!(endpoint.out_msg_queue)))
+            if get(msg, "method", "") == "textDocument/publishDiagnostics"
+                published[msg["params"]["uri"]] = msg["params"]["diagnostics"]
+            end
+        end
+        return published
+    end
+
+    server = LanguageServerInstance(IOBuffer(), IOBuffer(), dirname(Pkg.Types.Context().env.project_file))
+    server.workspace = JuliaWorkspaces.JuliaWorkspace()
+    server.jr_endpoint = endpoint
+    # Exercise the push path (publish_diagnostics) rather than the refresh request.
+    server.clientcapability_workspace_diagnostic_refreshsupport = false
+
+    mktempdir() do in_dir
+        mktempdir() do out_dir
+            in_path = joinpath(in_dir, "A.jl")
+            out_path = joinpath(out_dir, "B.jl")
+            src = "function foo() end begin"  # syntax error
+
+            in_uri = filepath2uri(in_path)
+            out_uri = filepath2uri(out_path)
+
+            # `in_dir` is a workspace folder; `out_dir` is not.
+            push!(server.workspaceFolders, in_dir)
+
+            LanguageServer.textDocument_didOpen_notification(
+                LanguageServer.DidOpenTextDocumentParams(LanguageServer.TextDocumentItem(in_uri, "julia", 0, src)),
+                server, server.jr_endpoint)
+            LanguageServer.textDocument_didOpen_notification(
+                LanguageServer.DidOpenTextDocumentParams(LanguageServer.TextDocumentItem(out_uri, "julia", 0, src)),
+                server, server.jr_endpoint)
+
+            # Both files are tracked, but only the in-workspace one counts as a
+            # workspace file.
+            @test JuliaWorkspaces.has_file(server.workspace, in_uri)
+            @test JuliaWorkspaces.has_file(server.workspace, out_uri)
+            @test LanguageServer.is_workspace_file(server, in_uri)
+            @test !LanguageServer.is_workspace_file(server, out_uri)
+
+            # JuliaWorkspaces itself still computes the diagnostic for the outside
+            # file (it stays generic); the LS is what refuses to emit it.
+            @test !isempty(JuliaWorkspaces.get_diagnostic(server.workspace, out_uri))
+
+            # Push path: published for the in-workspace file, never for the outside file.
+            published = drain_published(endpoint)
+            @test haskey(published, string(in_uri)) && !isempty(published[string(in_uri)])
+            @test !haskey(published, string(out_uri))
+
+            # Single-document pull returns an empty report for the outside file.
+            in_pull = LanguageServer.textDocument_diagnostic_request(
+                LanguageServer.DocumentDiagnosticParams(LanguageServer.TextDocumentIdentifier(in_uri), missing, missing),
+                server, server.jr_endpoint)
+            out_pull = LanguageServer.textDocument_diagnostic_request(
+                LanguageServer.DocumentDiagnosticParams(LanguageServer.TextDocumentIdentifier(out_uri), missing, missing),
+                server, server.jr_endpoint)
+            @test !isempty(in_pull.items)
+            @test isempty(out_pull.items)
+
+            # Workspace-wide pull excludes the outside file.
+            wpull = LanguageServer.workspace_diagnostic_request(
+                LanguageServer.WorkspaceDiagnosticParams(missing, LanguageServer.PreviousResultId[]),
+                server, server.jr_endpoint)
+            reported = Set(string(i.uri) for i in wpull.items)
+            @test string(in_uri) in reported
+            @test !(string(out_uri) in reported)
+        end
+    end
+end


### PR DESCRIPTION
Editors can open files outside any workspace folder. Those files are still tracked in JuliaWorkspaces so cross-file resolution keeps working, but a complete analysis is impossible without their project environment, so we should not report diagnostics for them.

Gate all three diagnostic-emission sites on the existing `_workspace_files` set (which already excludes out-of-workspace opened files): the push path (publish_diagnostics), the single-document pull (textDocument/diagnostic), and the workspace-wide pull (workspace/diagnostic).