### PR TITLE
fix(progress): count completed keys, not partial progress

### DIFF
--- a/src/progress.jl
+++ b/src/progress.jl
@@ -9,8 +9,10 @@ Reports are aggregated by *phase* — the part of `key` before `:` (`index`,
 `download`, `refresh`), or the whole key for single-operation phases
 (`package-caches`, `bootstrap`). Each phase is one bar, so a workspace with
 dozens of environments shows a single "Indexing environments (k/N)..." bar
-instead of dozens. The percentage is the mean completion across the phase's
-keys; the bar ends once every key has reported `>= 100`.
+instead of dozens. For index/refresh the percentage tracks the count of
+completed keys (`k/N`), so an in-progress environment never advances the bar
+past that count; the download bar keeps the mean, since a download key carries
+a real fraction. The bar ends once every key has reported `>= 100`.
 
 The closure only enqueues the report and never blocks: a worker task owns the
 token lifecycles and does the client round-trips, so a report arriving while a
@@ -53,7 +55,12 @@ _phase_label(phase, completed, total, message) =
 function _phase_report(phase::String, bar::PhaseBar, message::String)
     total = length(bar.seen)
     total == 0 && return (0, message)
-    pct = clamp(round(Int, (sum(values(bar.pct); init=0) + 100 * bar.completed) / total), 0, 100)
+    # Index/refresh keys are whole environments: only completed ones advance the
+    # bar, so the fill never runs past the "(k/total)" count shown beside it. A
+    # download key instead carries a real fraction, so its bar keeps the mean.
+    pct = phase == "download" ?
+        clamp(round(Int, (sum(values(bar.pct); init=0) + 100 * bar.completed) / total), 0, 100) :
+        clamp(round(Int, 100 * bar.completed / total), 0, 100)
     return (pct, _phase_label(phase, bar.completed, total, message))
 end
 

--- a/test/test_progress.jl
+++ b/test/test_progress.jl
@@ -33,7 +33,7 @@
     @test sent[2][2].token == dl_token
     @test sent[2][2].value.title == "Julia"
     @test sent[2][2].value.message == "Downloading package caches (0/1)..."
-    @test sent[2][2].value.percentage == 10
+    @test sent[2][2].value.percentage == 10  # download keeps its real fraction (mean)
 
     # A different phase gets its own token — bars run concurrently.
     cb("index:/p", "Indexing project...", 5)
@@ -49,7 +49,7 @@
     @test wait_for_sends(5)
     @test sent[5][2] isa ProgressParams{WorkDoneProgressReport}
     @test sent[5][2].token == dl_token
-    @test sent[5][2].value.percentage == 50
+    @test sent[5][2].value.percentage == 50  # download keeps its real fraction (mean)
 
     # The phase's last key reaching 100 ends its bar.
     cb("download:/p", "Downloads done", 100)
@@ -76,14 +76,16 @@
     @test sent[1][2].token != idx_token
 
     # The callback itself must never block: enqueueing a burst returns
-    # immediately and every report is delivered in order to the open bar.
+    # immediately and every report is delivered to the open bar. With one
+    # in-progress key the count-based percentage stays 0 until it completes,
+    # so delivery is verified by the send count and shared token.
     empty!(sent)
     for i in 1:10
         cb("index:/p", "Report $i", 10 + i)
     end
     @test wait_for_sends(10)
     @test all(p.token == sent[1][2].token for (_, p) in sent)
-    @test [p.value.percentage for (_, p) in sent] == [10 + i for i in 1:10]
+    @test all(p.value.percentage == 0 for (_, p) in sent)
 end
 
 @testitem "Progress bars aggregate by phase" begin
@@ -115,13 +117,13 @@ end
     @test all(p.token == token for (_, p) in sent[3:4])  # no new tokens created
     @test sent[4][2].value.message == "Indexing environments (0/3)..."
 
-    # Per-env percentages feed the shared bar's mean; completions bump the count.
+    # Only completed envs advance the bar; an in-progress env (a at 50%) does not.
     cb("index:/a", "Indexing Foo...", 50)
     cb("index:/b", "Indexing Bar...", 100)
     @test wait_for_sends(6)
     @test sent[6][2] isa ProgressParams{WorkDoneProgressReport}
     @test sent[6][2].value.message == "Indexing environments (1/3)..."
-    @test sent[6][2].value.percentage == 50  # (50 + 100 + 0) / 3
+    @test sent[6][2].value.percentage == 33  # 1 of 3 completed; a's in-progress 50% is ignored
 
     # The bar ends only once every key has completed.
     cb("index:/a", "Done", 100)


### PR DESCRIPTION
The aggregate phase bar filled from a mean that added in-progress keys' partial percentages, so the bar ran ahead of the "(k/N)" completed count shown beside it. For index/refresh (whole environments) the fill now tracks completed/total, matching the count; the download bar keeps the mean, since a download key carries a genuine fraction.
