### PR TITLE
feat: disable pull-mode diagnostics in favor of push mode

### DIFF
--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -1,9 +1,13 @@
+# Pull-mode diagnostics run synchronously on the dispatch task and delay
+# latency-critical requests (e.g. completion), so we use push mode instead.
+const PULL_DIAGNOSTICS_ENABLED = false
+
 function ServerCapabilities(client::ClientCapabilities)
     prepareSupport = !ismissing(client.textDocument) && !ismissing(client.textDocument.rename) && client.textDocument.rename.prepareSupport === true
 
     client_supports_pull_diagnostics = !ismissing(client.textDocument) && !ismissing(client.textDocument.diagnostic)
 
-    diagnostic_provider = client_supports_pull_diagnostics ?
+    diagnostic_provider = PULL_DIAGNOSTICS_ENABLED && client_supports_pull_diagnostics ?
         DiagnosticOptions(missing, true, true) : missing
 
     ServerCapabilities(
@@ -207,8 +211,10 @@ function initialized_notification(params::InitializedParams, server::LanguageSer
 
     end
 
-    # Record whether the client supports workspace/diagnostic/refresh
-    if !ismissing(server.clientCapabilities) &&
+    # Record whether the client supports workspace/diagnostic/refresh. Only
+    # relevant in pull mode; the flag also suppresses push-mode publishing.
+    if PULL_DIAGNOSTICS_ENABLED &&
+        !ismissing(server.clientCapabilities) &&
         !ismissing(server.clientCapabilities.workspace) &&
         !ismissing(server.clientCapabilities.workspace.diagnostics) &&
         !ismissing(server.clientCapabilities.workspace.diagnostics.refreshSupport) &&

--- a/test/test_publish_debounce.jl
+++ b/test/test_publish_debounce.jl
@@ -58,18 +58,29 @@ end
             change_doc(server, doc_uri, v, "f() = $v")
         end
 
-        # The burst marks the workspace dirty but publishes no sweep before the
-        # debounce delay has elapsed.
         @test server._sweep_pending
-        @test isempty(sweep_msgs(drain!(server.combined_msg_queue)))
+        final_gen = server._sweep_generation
 
-        sleep(0.5)
+        # Wait for the final generation's timer message. No wall-clock
+        # assumptions: on a slow machine timers from earlier (superseded)
+        # schedules may fire before we get here; those messages are stale.
+        msgs = Any[]
+        deadline = time() + 10
+        while !any(m -> m.generation == final_gen, msgs) && time() < deadline
+            append!(msgs, sweep_msgs(drain!(server.combined_msg_queue)))
+            sleep(0.02)
+        end
 
-        # Only the last scheduled timer fires: one sweep message for the burst.
-        msgs = sweep_msgs(drain!(server.combined_msg_queue))
-        @test length(msgs) == 1
+        # The burst coalesces: exactly one message carries the final
+        # generation, and stale messages don't run the sweep.
+        @test count(m -> m.generation == final_gen, msgs) == 1
+        for m in msgs
+            m.generation == final_gen && continue
+            LanguageServer.handle_publish_sweep_msg!(server, m.generation)
+            @test server._sweep_pending
+        end
 
-        LanguageServer.handle_publish_sweep_msg!(server, msgs[1].generation)
+        LanguageServer.handle_publish_sweep_msg!(server, final_gen)
         @test !server._sweep_pending
     finally
         LanguageServer.SWEEP_DEBOUNCE_SECONDS[] = old_delay
@@ -121,7 +132,12 @@ end
 
 @testitem "publish sweep handler: stale generations and drain guard" setup=[TestSetup, DebounceHelpers] begin
     old_delay = LanguageServer.SWEEP_DEBOUNCE_SECONDS[]
-    LanguageServer.SWEEP_DEBOUNCE_SECONDS[] = 100.0  # timers must not fire during this test
+    old_max_latency = LanguageServer.SWEEP_MAX_LATENCY_SECONDS[]
+    # Timers must not fire and the max-latency budget must not run out during
+    # this test: the drain guard only defers while the budget lasts, and slow
+    # CI runners can spend multiple seconds on JIT between the calls below.
+    LanguageServer.SWEEP_DEBOUNCE_SECONDS[] = 100.0
+    LanguageServer.SWEEP_MAX_LATENCY_SECONDS[] = 10_000.0
     try
         # An uninitialized server suffices: the handler's bookkeeping is
         # independent of the workspace (run_publish_sweep no-ops without one).
@@ -151,5 +167,6 @@ end
         @test !server._sweep_pending
     finally
         LanguageServer.SWEEP_DEBOUNCE_SECONDS[] = old_delay
+        LanguageServer.SWEEP_MAX_LATENCY_SECONDS[] = old_max_latency
     end
 end


### PR DESCRIPTION
Pull-mode diagnostic requests run synchronously on the single dispatch task, so a workspace/diagnostic request that lints the whole workspace delays latency-critical requests like completion. Stop advertising the diagnosticProvider capability and don't record the client's refresh support (which suppresses push publishing), so the debounced push-mode pipeline takes over. A single PULL_DIAGNOSTICS_ENABLED const gates both spots to make re-enabling for comparison easy.