### PR TITLE
Fix docs build errors

### DIFF
--- a/docs/src/syntax.md
+++ b/docs/src/syntax.md
@@ -8,17 +8,17 @@ Pages   = ["syntax.md"]
 ## Main
 ```@autodocs
 Modules = [LanguageServer]
-Pages   = readdir("../src")
+Pages   = [joinpath("src", f) for f in readdir("../src") if endswith(f, ".jl")]
 ```
 
 ## Requests
 ```@autodocs
 Modules = [LanguageServer]
-Pages   = readdir("../src/requests")
+Pages   = [joinpath("src", "requests", f) for f in readdir("../src/requests")]
 ```
 
 ## Protocol
 ```@autodocs
 Modules = [LanguageServer]
-Pages   = readdir("../src/protocol")
+Pages   = [joinpath("src", "protocol", f) for f in readdir("../src/protocol")]
 ```

--- a/src/runserver.jl
+++ b/src/runserver.jl
@@ -7,9 +7,9 @@ The same options can be passed to `runserver` as to
 [`LanguageServerInstance`](@ref). If `env_path` is not specified,
 attempt to pick an environment by considering in order of priority:
 
-1. [`ARGS`[1]](@ref): the first command-line argument passed to the
+1. `ARGS[1]`: the first command-line argument passed to the
    invocation of `julia`.
-2. The Julia project containing [`pwd()`](@ref).
+2. The Julia project containing `pwd()`.
 3. The default Julia environment withing `.julia/environments/v#.#`.
 
 # Examples


### PR DESCRIPTION
The `deploy-docs` job fails with `makedocs` errors `[:autodocs_block, :cross_references]`:

- The `@autodocs` blocks in `docs/src/syntax.md` used bare filenames from `readdir`, which Documenter matches by path *suffix*. `textdocument.jl` exists in both `src/` and `src/requests/`, and `protocol/document.jl` is itself a suffix of `textdocument.jl`, so the same docstrings were pulled into multiple blocks. The `Pages` entries are now qualified with their directory, making the matches unambiguous.
- The `runserver` docstring had `@ref` links on the Base names `ARGS` and `pwd()`, which cannot resolve; they are now plain code formatting.

Verified locally: `julia --project=docs docs/make.jl` completes through rendering with no errors, and every docstring anchor in the rendered `syntax.html` appears exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)