### PR TITLE
Publish `option_skip` to test item clients

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 JSON = "0.20, 0.21"
 JSONRPC = "3"
-JuliaWorkspaces = "11"
+JuliaWorkspaces = "12"
 LoggingExtras = "1.2"
 PrecompileTools = "1"
 Salsa = "2.5.2"

--- a/src/extensions/extensions.jl
+++ b/src/extensions/extensions.jl
@@ -15,6 +15,7 @@ end
     optionDefaultImports::Bool
     optionTags::Vector{String}
     optionSetup::Vector{String}
+    optionSkip::Union{Bool,String}
 end
 
 @dict_readable struct TestSetupDetail <: Outbound

--- a/src/testitem_diagnostic_marking.jl
+++ b/src/testitem_diagnostic_marking.jl
@@ -212,7 +212,8 @@ function publish_tests(server::LanguageServerInstance, updated_files, deleted_fi
                     codeRange = Range(st, i.code_range),
                     optionDefaultImports = i.option_default_imports,
                     optionTags = string.(i.option_tags),
-                    optionSetup = string.(i.option_setup)
+                    optionSetup = string.(i.option_setup),
+                    optionSkip = i.option_skip
                 ) for i in testitems_results.testitems
             ]
             testsetups= TestSetupDetail[


### PR DESCRIPTION
Forwards the `skip` keyword argument of `@testitem` through `textDocument/publishTests`.

JuliaWorkspaces records `option_skip` on `TestItemDetail` (julia-vscode/JuliaWorkspaces.jl#255, shipped in 12.0.0), but `publish_tests` dropped it. Without this the VS Code extension cannot see `skip` and so cannot forward it to TestItemControllers — a test item marked `skip=true` would silently run anyway.

## Wire shape

`optionSkip` mirrors the JuliaWorkspaces type, `Union{Bool,String}`:

- `false` / `true` — a literal, known statically
- a string — the source text of an expression the **test process** evaluates immediately before the test item would run

Keeping the union rather than normalising to a string lets a client distinguish a test item that never runs (render it as skipped in the tree) from one whose outcome is only known at run time (run it and find out). The expression must be evaluated worker-side because it may inspect the worker's environment, e.g. `VERSION < v"1.11"` or `Sys.iswindows()`, which can differ from the language server's.

`@dict_readable` handles the union correctly — `field_type` collapses a non-`Missing` union to `Any`, so the value passes through unconverted. Verified both variants serialize to their natural JSON forms (boolean vs string) and round-trip through the generated `Dict` constructor.

## Compat

Bumps `JuliaWorkspaces` to `"12"`. Besides `option_skip`, 12.0.0 changes test item ids from positional (`<uri>:<n>`) to stable (`<relpath>::<label>`) — ids are forwarded verbatim here, so no change was needed in this repo for that.

## Downstream

The VS Code extension needs a matching change to read `optionSkip` and forward it when creating a test run; TestItemControllers' `json_protocol.jl` gains the corresponding field in julia-testitems/TestItemControllers.jl#39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)