### PR TITLE
Require JuliaWorkspaces 13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 JSON = "0.20, 0.21"
 JSONRPC = "3"
-JuliaWorkspaces = "12"
+JuliaWorkspaces = "13"
 LoggingExtras = "1.2"
 PrecompileTools = "1"
 Salsa = "2.5.2"


### PR DESCRIPTION
JuliaWorkspaces 13.0.0 changes test item ids from `<path>::<label>` to `<Package>@<uuid8>/<path>::<label>`, so that two packages each containing `test/runtests.jl` with a test item of the same name no longer mint identical ids (julia-vscode/JuliaWorkspaces.jl#257).

This package forwards ids verbatim through `publish_tests` and never inspects their shape, so **no code change is needed** — but the compat bound has to move, or a resolve keeps this on JuliaWorkspaces 12 and clients keep seeing the old format.

## Verification

Full suite against the released JuliaWorkspaces 13.0.0: **178207 pass, 1 broken** — identical to the counts before the bump.

## Note for the extension

Ids change format once, so any persisted state keyed on them is invalidated. Thereafter it survives inserting a test item above another, which it never did under the positional ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)