### PR TITLE
Fix the MarkedString hash test on Julia 1.13

### DIFF
--- a/test/test_protocol.jl
+++ b/test/test_protocol.jl
@@ -1,10 +1,13 @@
 @testitem "MarkedString hash uses the two-arg method (#1381)" begin
     ms(s) = LanguageServer.MarkedString("julia", s)
 
-    # The hash protocol requires the two-arg `hash(x, h::UInt)`. A stray one-arg
-    # `Base.hash(x)` made `hash(x)` and `hash(x, zero(UInt))` disagree, breaking
-    # hashing in Dicts/unique. They must now be consistent and value-based.
-    @test hash(ms("x")) == hash(ms("x"), zero(UInt))
+    # The hash protocol requires the two-arg `hash(x, h::UInt)`. #1381 was a stray one-arg
+    # `Base.hash(x::MarkedString)`, which made hashing identity-based and broke Dicts and
+    # `unique`. Assert that method is absent rather than comparing `hash(x)` against
+    # `hash(x, zero(UInt))`: Julia 1.13 stopped defining the generic one-arg `hash(x)` as
+    # `hash(x, zero(UInt))`, so that comparison is now false for every type, `Int` included,
+    # and says nothing about MarkedString.
+    @test which(hash, Tuple{LanguageServer.MarkedString}).sig === Tuple{typeof(hash),Any}
     @test hash(ms("x")) == hash(ms("x"))
     @test hash(ms("x"), UInt(7)) == hash(ms("x"), UInt(7))
 


### PR DESCRIPTION
Julia 1.13 stopped defining the generic one-arg `hash(x)` as `hash(x, zero(UInt))`. The regression test for #1381 compared exactly those two, so it now fails on 1.13 — and the comparison is false for every type there, `Int` included, so it says nothing about `MarkedString` any more.

#1381 itself was a stray one-arg `Base.hash(x::MarkedString)` that made hashing identity-based and broke `Dict` and `unique`. This asserts that no such method exists — `which(hash, Tuple{MarkedString})` has to resolve to the generic `hash(x)` — which catches the original regression on every supported version. The value-based invariants next to it are unchanged.

Found while auditing the stack for Julia 1.13 readiness.

Verified: 32/32 on 1.12.7 and on 1.13.0-rc3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)