### PR TITLE
Only offer formatting for Julia documents

### DIFF
--- a/src/requests/features.jl
+++ b/src/requests/features.jl
@@ -14,17 +14,33 @@ function textDocument_definition_request(params::TextDocumentPositionParams, ser
     return unique!(locations)
 end
 
+"""
+LSP 3.17 `ErrorCodes.RequestFailed`: the request was well-formed and understood,
+but could not be carried out. The message is meant to be shown to the user, so it
+must read as an explanation rather than as an internal exception dump.
+"""
+const LSP_REQUEST_FAILED = -32803
+
+# A formatting failure is almost always "this file is not valid Julia", which is
+# the user's code, not a server fault. Lead with the actionable sentence and keep
+# the underlying parser output after it for the logs.
+function format_failure_error(uri::URI, err)
+    name = something(uri2filepath(uri), string(uri))
+    detail = sprint(showerror, err)
+    return JSONRPC.JSONRPCError(
+        LSP_REQUEST_FAILED,
+        "Could not format $(basename(name)) because it could not be parsed as Julia code.\n\n$detail",
+        nothing
+    )
+end
+
 function textDocument_formatting_request(params::DocumentFormattingParams, server::LanguageServerInstance, conn)
     uri = params.textDocument.uri
 
     file_edit = try
         JuliaWorkspaces.get_format_edits(server.workspace, uri)
     catch err
-        return JSONRPC.JSONRPCError(
-            -32000,
-            "Failed to format document: $err.",
-            nothing
-        )
+        return format_failure_error(uri, err)
     end
 
     # A file the configuration excludes is not an error; the gesture simply
@@ -45,11 +61,7 @@ function textDocument_range_formatting_request(params::DocumentRangeFormattingPa
     file_edit = try
         JuliaWorkspaces.get_format_edits(server.workspace, uri, start_line, stop_line)
     catch err
-        return JSONRPC.JSONRPCError(
-            -32000,
-            "Failed to format document: $err.",
-            nothing
-        )
+        return format_failure_error(uri, err)
     end
 
     file_edit === nothing && return TextEdit[]

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -201,7 +201,10 @@ function initialized_notification(params::InitializedParams, server::LanguageSer
     # from using the formatter that actually can (it picks a single provider per
     # document). `ServerCapabilities` leaves the static capability out whenever the
     # client advertises dynamic registration, so the two must stay in sync.
-    if !ismissing(server.clientCapabilities)
+    #
+    # `conn === nothing` means there is no client to register with (the server is
+    # being driven directly, as the tests do), so there is nothing to send.
+    if conn !== nothing && !ismissing(server.clientCapabilities)
         if client_supports_dynamic_registration(server.clientCapabilities, :formatting)
             push!(
                 client_capabilities_registrations,

--- a/src/requests/init.jl
+++ b/src/requests/init.jl
@@ -2,6 +2,23 @@
 # latency-critical requests (e.g. completion), so we use push mode instead.
 const PULL_DIAGNOSTICS_ENABLED = false
 
+# The languages whose documents we are willing to format. The formatter parses a
+# whole document as Julia code, so it must only ever be offered for Julia source.
+# Markdown (and Julia-markdown, which is Markdown with Julia chunks) is part of
+# the client's document selector for every *other* feature, but formatting one of
+# those as a single Julia file always fails — and, worse, registering as their
+# formatting provider makes the editor pick us over the real Markdown formatter.
+const FORMATTING_LANGUAGES = ["julia"]
+
+formatting_document_selector() = DocumentSelector([DocumentFilter(l, missing, missing) for l in FORMATTING_LANGUAGES])
+
+function client_supports_dynamic_registration(client::ClientCapabilities, capability::Symbol)
+    ismissing(client.textDocument) && return false
+    cap = getproperty(client.textDocument, capability)
+    ismissing(cap) && return false
+    return cap.dynamicRegistration === true
+end
+
 function ServerCapabilities(client::ClientCapabilities)
     prepareSupport = !ismissing(client.textDocument) && !ismissing(client.textDocument.rename) && client.textDocument.rename.prepareSupport === true
 
@@ -9,6 +26,14 @@ function ServerCapabilities(client::ClientCapabilities)
 
     diagnostic_provider = PULL_DIAGNOSTICS_ENABLED && client_supports_pull_diagnostics ?
         DiagnosticOptions(missing, true, true) : missing
+
+    # A static capability applies to the client's whole document selector, which
+    # includes Markdown. When the client can handle dynamic registration we
+    # advertise nothing here and register in `initialized_notification` instead,
+    # scoped to `FORMATTING_LANGUAGES`. Clients without dynamic registration keep
+    # the old, broader behaviour rather than losing formatting altogether.
+    formatting_provider = client_supports_dynamic_registration(client, :formatting) ? missing : true
+    range_formatting_provider = client_supports_dynamic_registration(client, :rangeFormatting) ? missing : true
 
     ServerCapabilities(
         TextDocumentSyncOptions(
@@ -32,8 +57,8 @@ function ServerCapabilities(client::ClientCapabilities)
         missing,
         DocumentLinkOptions(false, missing),
         false,
-        true,
-        true,
+        formatting_provider,
+        range_formatting_provider,
         missing,
         RenameOptions(missing, prepareSupport),
         false,
@@ -168,6 +193,36 @@ function initialized_notification(params::InitializedParams, server::LanguageSer
             client_capabilities_registrations,
             Registration(string(uuid4()), "workspace/didChangeConfiguration", missing)
         )
+    end
+
+    # Register formatting only for Julia source. The static capability would apply
+    # to the client's whole document selector, which also contains Markdown and
+    # Julia-markdown; we cannot format those, and claiming we can stops the editor
+    # from using the formatter that actually can (it picks a single provider per
+    # document). `ServerCapabilities` leaves the static capability out whenever the
+    # client advertises dynamic registration, so the two must stay in sync.
+    if !ismissing(server.clientCapabilities)
+        if client_supports_dynamic_registration(server.clientCapabilities, :formatting)
+            push!(
+                client_capabilities_registrations,
+                Registration(
+                    string(uuid4()),
+                    "textDocument/formatting",
+                    DocumentFormattingRegistrationOptions(formatting_document_selector(), missing)
+                )
+            )
+        end
+
+        if client_supports_dynamic_registration(server.clientCapabilities, :rangeFormatting)
+            push!(
+                client_capabilities_registrations,
+                Registration(
+                    string(uuid4()),
+                    "textDocument/rangeFormatting",
+                    DocumentRangeFormattingRegistrationOptions(formatting_document_selector(), missing)
+                )
+            )
+        end
     end
 
     if !ismissing(server.clientCapabilities) &&

--- a/test/requests/test_formatting.jl
+++ b/test/requests/test_formatting.jl
@@ -39,7 +39,7 @@
     @test !isempty(result)
 end
 
-@testitem "formatting a file with a syntax error reports -32000 for both request kinds" setup=[TestSetup, SharedServer] begin
+@testitem "formatting a file with a syntax error reports RequestFailed for both request kinds" setup=[TestSetup, SharedServer] begin
     import JuliaWorkspaces
     using LanguageServer.URIs2
 
@@ -53,7 +53,13 @@ end
             LanguageServer.FormattingOptions(4, true, missing, missing, missing)),
         server, server.jr_endpoint)
     @test result isa LanguageServer.JSONRPC.JSONRPCError
-    @test result.code == -32000
+    # LSP 3.17 `RequestFailed`: understood, but cannot be carried out. The
+    # message is shown to the user, so it must name the file and read as an
+    # explanation rather than as an internal exception dump.
+    @test result.code == LanguageServer.LSP_REQUEST_FAILED
+    @test result.code == -32803
+    @test occursin("code.jl", result.msg)
+    @test !occursin("Failed to format document", result.msg)
 
     result = LanguageServer.textDocument_range_formatting_request(
         LanguageServer.DocumentRangeFormattingParams(
@@ -62,5 +68,64 @@ end
             LanguageServer.FormattingOptions(4, true, missing, missing, missing)),
         server, server.jr_endpoint)
     @test result isa LanguageServer.JSONRPC.JSONRPCError
-    @test result.code == -32000
+    @test result.code == LanguageServer.LSP_REQUEST_FAILED
+    @test occursin("code.jl", result.msg)
+end
+
+@testitem "formatting is only offered for Julia documents" begin
+    import JSON
+
+    # The formatter parses a whole document as Julia, so we must not claim to be
+    # the formatting provider for Markdown / Julia-markdown: the editor picks a
+    # single provider per document, so claiming it also suppresses the formatter
+    # that could actually do the job.
+    selector = LanguageServer.formatting_document_selector()
+    languages = [f.language for f in selector]
+    @test languages == ["julia"]
+    @test !("markdown" in languages)
+    @test !("juliamarkdown" in languages)
+
+    # A client that can handle dynamic registration gets no static capability,
+    # because a static one would apply to the client's whole document selector.
+    dynamic = LanguageServer.ClientCapabilities(Dict("textDocument" => Dict(
+        "formatting" => Dict("dynamicRegistration" => true),
+        "rangeFormatting" => Dict("dynamicRegistration" => true))))
+    caps = LanguageServer.ServerCapabilities(dynamic)
+    @test caps.documentFormattingProvider === missing
+    @test caps.documentRangeFormattingProvider === missing
+
+    # ... and `missing` must be omitted from the wire, not serialised as null,
+    # or the client still sees a formatting provider.
+    wire = JSON.parse(JSON.json(caps))
+    @test !haskey(wire, "documentFormattingProvider")
+    @test !haskey(wire, "documentRangeFormattingProvider")
+
+    # A client without dynamic registration keeps the previous behaviour rather
+    # than losing formatting altogether.
+    for client in (
+        LanguageServer.ClientCapabilities(Dict("textDocument" => Dict(
+            "formatting" => Dict("dynamicRegistration" => false)))),
+        LanguageServer.ClientCapabilities(Dict{String,Any}()),
+    )
+        static_caps = LanguageServer.ServerCapabilities(client)
+        @test static_caps.documentFormattingProvider === true
+        @test static_caps.documentRangeFormattingProvider === true
+    end
+
+    # The two capabilities are decided independently.
+    mixed = LanguageServer.ServerCapabilities(LanguageServer.ClientCapabilities(
+        Dict("textDocument" => Dict(
+            "formatting" => Dict("dynamicRegistration" => true),
+            "rangeFormatting" => Dict("dynamicRegistration" => false)))))
+    @test mixed.documentFormattingProvider === missing
+    @test mixed.documentRangeFormattingProvider === true
+
+    # The registration we send must carry the Julia-only selector.
+    registration = LanguageServer.Registration(
+        "id", "textDocument/formatting",
+        LanguageServer.DocumentFormattingRegistrationOptions(selector, missing))
+    wire = JSON.parse(JSON.json(LanguageServer.RegistrationParams([registration])))
+    @test wire["registrations"][1]["method"] == "textDocument/formatting"
+    @test wire["registrations"][1]["registerOptions"]["documentSelector"] ==
+        [Dict("language" => "julia")]
 end


### PR DESCRIPTION
## Crash signature

From the julia-vscode **insider-channel** Application Insights crash telemetry, last 30 days. This is
the single largest crash signature in the entire corpus:

| Signature | Events | Users |
| --- | --- | --- |
| `Error at handleResponse` — `Failed to format document: …` | **3645** | 19 |

That is ~70% of all reported extension "crashes" for the period. A representative message:

```
Failed to format document: ErrorException("ParseError:
# Error @ line 3:… constant horizontal body force drives the flow throughout the …
#└────────────────────────────────────────┘ ── extra tokens after end of expression")
```

The text being "parsed" is English prose: these are **Markdown files** being sent to the Julia
formatter, overwhelmingly by format-on-save.

## Root cause

The client's document selector covers `julia`, `juliamarkdown` **and** `markdown` (all three get
diagnostics, completions, and so on). `ServerCapabilities` advertised formatting statically:

```julia
documentFormattingProvider      = true
documentRangeFormattingProvider = true
```

A static capability applies to the client's *whole* document selector, so the server registered as a
formatting provider for plain Markdown as well. Two consequences:

1. `get_format_edits` parses the entire document as Julia, so formatting a Markdown file always fails
   and returns a `JSONRPCError`, which the client rethrows and VS Code reports as an extension fault.
2. More importantly, an editor picks **one** formatting provider per document. By claiming the
   capability we were also *suppressing the real Markdown formatter*. Simply returning "no edits" would
   not have fixed that — we have to not be registered for those languages at all.

## Fix

**Scope the registration.** Advertise `documentFormattingProvider` / `documentRangeFormattingProvider`
as `missing` whenever the client supports dynamic registration, and instead register
`textDocument/formatting` and `textDocument/rangeFormatting` from `initialized_notification` with a
document selector limited to `language: julia`. The `client/registerCapability` machinery was already
there for `workspace/didChangeWatchedFiles`.

Formatting a Markdown file now falls through to whichever formatter the user actually configured.

`juliamarkdown` (`.jmd`) is excluded too: it is Markdown with Julia chunks, so formatting it as a single
Julia file fails the same way. It keeps every other language-server feature.

Clients that do **not** advertise dynamic registration keep the previous static capability rather than
silently losing formatting. The two decisions are made by the same predicate so they cannot drift apart,
and the capabilities are decided independently of each other.

**Report syntax errors as user-facing failures.** A smaller slice of these events are genuine `.jl`
files that do not parse. That is the user's code, not a server bug, but `-32000` with a stringified
Julia exception is the wrong way to say so. These now return LSP 3.17 `RequestFailed` (`-32803`) with a
message written for a human and naming the file.

Note this alone does not stop the crash report: `vscode-languageclient`'s `handleFailedRequest` only
swallows `PendingResponseRejected`, `ConnectionInactive`, `RequestCancelled`, `ServerCancelled` and
`ContentModified`, and logs+rethrows everything else including `RequestFailed`. The client-side half is
a companion PR against julia-vscode that catches this in formatting middleware and shows the user a
warning.

## Testing

`test/requests/test_formatting.jl`:

- Updated the existing syntax-error test to assert the new `RequestFailed` code, that the message names
  the file, and that it no longer leaks the old internal wording.
- Added `formatting is only offered for Julia documents`, covering: the selector contains `julia` and
  neither `markdown` nor `juliamarkdown`; a dynamic-registration client gets `missing` for both
  capabilities; `missing` is **omitted from the serialised JSON** rather than sent as `null` (otherwise
  the client would still see a provider); a non-dynamic client and a client that advertises nothing both
  keep `true`; the two capabilities are decided independently; and the emitted registration serialises to
  the expected LSP wire shape with the Julia-only selector.

```
LanguageServer                                                                         |   27     27
  test/requests/test_formatting.jl                                                     |   27     27
    formatting an excluded file is a no-op, not an error                               |    4      4
    formatting a file with a syntax error reports RequestFailed for both request kinds |    8      8
    formatting is only offered for Julia documents                                     |   15     15
```
