### PR TITLE
Return ContentModified for stale document offsets

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -166,6 +166,8 @@ struct MissingDocumentError <: Exception
     uri::URI
 end
 
+const JSONRPC_CONTENT_MODIFIED = -32801
+
 function invoke_handler(func, params, server::LanguageServerInstance, conn)
     try
         if USE_REVISE[] && isdefined(Main, :Revise)
@@ -179,9 +181,15 @@ function invoke_handler(func, params, server::LanguageServerInstance, conn)
             return func(params, server, conn)
         end
     catch err
-        err isa MissingDocumentError || rethrow()
-        @debug "Handler $(nameof(func)) targeted a document not in the server" uri = err.uri
-        return JSONRPC.JSONRPCError(-32602, "Document not available: $(err.uri).", nothing)
+        if err isa MissingDocumentError
+            @debug "Handler $(nameof(func)) targeted a document not in the server" uri = err.uri
+            return JSONRPC.JSONRPCError(-32602, "Document not available: $(err.uri).", nothing)
+        elseif err isa LSOffsetError
+            @debug "Handler $(nameof(func)) targeted a position outside the current document content" exception = (err, catch_backtrace())
+            return JSONRPC.JSONRPCError(JSONRPC_CONTENT_MODIFIED, "Content modified.", nothing)
+        else
+            rethrow()
+        end
     end
 end
 

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -62,20 +62,20 @@ function textDocument_didSave_notification(params::DidSaveTextDocumentParams, se
     uri = params.textDocument.uri
     st = jw_source_text(server, uri)
     if params.text isa String && st.content != params.text
-        # Only treat a save-time text mismatch as a fatal sync error when the
-        # document is actually open in the editor and has received at least one
-        # versioned update. Mismatches for closed/unversioned documents are
-        # spurious (e.g. workspace files we track but the client never synced),
-        # so we ignore them rather than crashing the server (see #1390).
+        # Only use save-time text to resynchronize documents that are actually
+        # open in the editor and have received at least one versioned update.
+        # Mismatches for closed/unversioned documents are spurious (e.g.
+        # workspace files we track but the client never synced), so we ignore
+        # them rather than changing server state (see #1390).
         if haskey(server._open_file_versions, uri) && get(server._open_file_versions, uri, 0) > 0
-            println(stderr, "Mismatch between server and client text")
-            println(stderr, "========== BEGIN SERVER SIDE TEXT ==========")
-            println(stderr, st.content)
-            println(stderr, "========== END SERVER SIDE TEXT ==========")
-            println(stderr, "========== BEGIN CLIENT SIDE TEXT ==========")
-            println(stderr, params.text)
-            println(stderr, "========== END CLIENT SIDE TEXT ==========")
-            throw(LSSyncMismatch("Mismatch between server and client text for $(uri). _open_in_editor is $(haskey(server._open_file_versions, uri)). _workspace_file is $(uri in server._workspace_files). _version is $(get(server._open_file_versions, uri, 0))."))
+            @warn "Resynchronizing textDocument/didSave from client text after a server/client mismatch" uri=uri version=get(server._open_file_versions, uri, 0) server_bytes=sizeof(st.content) client_bytes=sizeof(params.text)
+            new_text_file = JuliaWorkspaces.TextFile(uri, JuliaWorkspaces.SourceText(params.text, st.language_id))
+            JuliaWorkspaces.update_file!(server.workspace, new_text_file)
+            if haskey(server._files_from_disc, uri)
+                server._files_from_disc[uri] = new_text_file
+            end
+            publish_file_diagnostics_testitems(server, [uri])
+            schedule_publish_sweep!(server)
         end
     end
 end
@@ -93,15 +93,23 @@ function textDocument_didChange_notification(params::DidChangeTextDocumentParams
     uri = params.textDocument.uri
 
     if !haskey(server._open_file_versions, uri)
+        @error "Received textDocument/didChange for a document that is not open; change cannot be applied" uri=uri client_version=params.textDocument.version
         error("This should not happen")
     end
 
-    if params.textDocument.version < server._open_file_versions[uri]
-        error("The client and server have different textDocument versions for $(uri). LS version is $(server._open_file_versions[uri]), request version is $(params.textDocument.version).")
+    current_version = server._open_file_versions[uri]
+    if params.textDocument.version < current_version
+        @error "Received stale textDocument/didChange; change was rejected and the document may need to be reopened to resynchronize" uri=uri server_version=current_version client_version=params.textDocument.version
+        error("The client and server have different textDocument versions for $(uri). LS version is $(current_version), request version is $(params.textDocument.version).")
     end
 
     st = jw_source_text(server, uri)
-    new_content = apply_text_edits(st, params.contentChanges)
+    new_content = try
+        apply_text_edits(st, params.contentChanges)
+    catch err
+        @error "Failed to apply textDocument/didChange; keeping previous server text until a full-content save or reopen resynchronizes it" uri=uri server_version=current_version client_version=params.textDocument.version change_count=length(params.contentChanges) exception=(err, catch_backtrace())
+        rethrow()
+    end
 
     new_text_file = JuliaWorkspaces.TextFile(uri, JuliaWorkspaces.SourceText(new_content, st.language_id))
     JuliaWorkspaces.update_file!(server.workspace, new_text_file)

--- a/test/requests/test_request_handling.jl
+++ b/test/requests/test_request_handling.jl
@@ -38,6 +38,23 @@ end
     closetestdoc()
 end
 
+@testitem "documentHighlight past EOF reports ContentModified" setup=[TestSetup, SharedServer] begin
+    settestdoc("x = 1")
+
+    params = LanguageServer.DocumentHighlightParams(
+        LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"),
+        LanguageServer.Position(1, 0),
+        missing,
+        missing,
+    )
+    wrapped = LanguageServer.request_wrapper(LanguageServer.textDocument_documentHighlight_request, server)
+    result = wrapped(server.jr_endpoint, params, missing)
+    @test result isa LanguageServer.JSONRPC.JSONRPCError
+    @test result.code == LanguageServer.JSONRPC_CONTENT_MODIFIED
+
+    closetestdoc()
+end
+
 @testitem "editor pid monitoring (#1379)" setup=[TestSetup, SharedServer] begin
     # No editor pid known → no monitor task.
     server.editor_pid = nothing

--- a/test/requests/test_textdocument.jl
+++ b/test/requests/test_textdocument.jl
@@ -38,7 +38,7 @@ end
     @test r2.stop == LanguageServer.Position(0, 3)
 end
 
-@testitem "TextDocument didSave sync mismatch (#1390)" setup=[TestSetup, SharedServer] begin
+@testitem "TextDocument didSave sync mismatch resynchronizes open docs (#1390)" setup=[TestSetup, SharedServer] begin
     u = uri"untitled:synctest"
     LanguageServer.textDocument_didOpen_notification(LanguageServer.DidOpenTextDocumentParams(LanguageServer.TextDocumentItem(u, "julia", 0, "x = 1")), server, nothing)
 
@@ -49,11 +49,13 @@ end
     # Bump the version above 0 with a real edit.
     LanguageServer.textDocument_didChange_notification(LanguageServer.DidChangeTextDocumentParams(LanguageServer.VersionedTextDocumentIdentifier(u, 2), [LanguageServer.TextDocumentContentChangeEvent(missing, missing, "y = 2")]), server, nothing)
 
-    # Now a genuine mismatch (open, version > 0) is still reported.
-    @test_throws LanguageServer.LSSyncMismatch LanguageServer.textDocument_didSave_notification(LanguageServer.DidSaveTextDocumentParams(LanguageServer.TextDocumentIdentifier(u), "different"), server, nothing)
+    # Now a genuine mismatch (open, version > 0) resynchronizes from the full
+    # save text instead of leaving the server permanently stale.
+    @test (LanguageServer.textDocument_didSave_notification(LanguageServer.DidSaveTextDocumentParams(LanguageServer.TextDocumentIdentifier(u), "different"), server, nothing); true)
+    @test LanguageServer.jw_text(server, u) == "different"
 
     # Matching text never crashes.
-    @test (LanguageServer.textDocument_didSave_notification(LanguageServer.DidSaveTextDocumentParams(LanguageServer.TextDocumentIdentifier(u), "y = 2"), server, nothing); true)
+    @test (LanguageServer.textDocument_didSave_notification(LanguageServer.DidSaveTextDocumentParams(LanguageServer.TextDocumentIdentifier(u), "different"), server, nothing); true)
 
     LanguageServer.textDocument_didClose_notification(LanguageServer.DidCloseTextDocumentParams(LanguageServer.TextDocumentIdentifier(u)), server, nothing)
 end


### PR DESCRIPTION
## Crash signature

Insiders telemetry shows `LanguageServer.LSOffsetError: index_at crashed` from `textDocument/documentHighlight`: `index_at(st::SourceText, line=54, ...)` throws in `src/textdocument.jl` after `highlight.jl` resolves the requested LSP position. The reported `line_indices` has 53 entries, so the request position names a line beyond the server's current document text. A rarer variant reaches the same offset conversion through `index_at(doc::TextDocument, ...)`.

## Root cause

I checked `didOpen`, `didChange`, `didClose`, `didSave`, `index_at`, `apply_text_edits`, and `documentHighlight`. The dispatch and file-watcher ordering paths are not needed to explain this: `didChange` updates JuliaWorkspaces and `_open_file_versions` only after all validation and `apply_text_edits` succeed. If an incremental change is rejected or its range is already outside the server's current `SourceText`, `apply_text_edits` throws before either the text or version advances. The server then remains behind the client; subsequent positional read requests can refer to lines that exist only in the client buffer and hit `LSOffsetError` in `index_at`.

## Fix

Translate `LSOffsetError` in the existing handler boundary to `JSONRPCError(-32801, "Content modified.", nothing)`, the LSP `ContentModified` code that VS Code's language client treats as a benign invalidated request. I kept `documentHighlight` strict instead of using `forgiving_mode`, because clamping would answer a request at the wrong position rather than telling the client the content changed. I also made failed `didChange` paths log the affected URI, server/client versions, and change count, and used full `didSave` text to resynchronize an open document when a save-time mismatch proves the server copy is stale.

## Testing

- `julia -e 'Meta.parseall(read("src/textdocument.jl", String)); Meta.parseall(read("src/requests/textdocument.jl", String)); Meta.parseall(read("src/languageserverinstance.jl", String)); Meta.parseall(read("test/requests/test_request_handling.jl", String)); Meta.parseall(read("test/requests/test_textdocument.jl", String))'`
- TestItemRunner for `test/requests/test_request_handling.jl` and `test/requests/test_textdocument.jl`: 7 test items passed, including the new `documentHighlight past EOF reports ContentModified` coverage.
- `git --no-pager diff --check`