### PR TITLE
Attach document sync context to LSOffsetError crash reports

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -166,6 +166,42 @@ struct MissingDocumentError <: Exception
     uri::URI
 end
 
+# Summarise the server's synchronisation state for `uri` as `key=value` pairs.
+# Appended to sync-related crash messages (`LSOffsetError`, `LSSyncMismatch`)
+# so a crash report alone is enough to tell where the server's copy of a
+# document came from (editor buffer vs. disc) and how far behind it might be.
+# Reports only the URI scheme, never the full URI: crash messages are sent
+# verbatim, and a file path would leak the user's home directory.
+function document_sync_context(server::LanguageServerInstance, uri::Union{URI,Nothing})
+    uri === nothing && return "uri=<unavailable>"
+    try
+        io = IOBuffer()
+        is_open = haskey(server._open_file_versions, uri)
+        from_disc = haskey(server._files_from_disc, uri)
+        in_workspace = JuliaWorkspaces.has_file(server.workspace, uri)
+        print(io,
+            "scheme=", uri.scheme,
+            " open=", is_open,
+            " version=", get(server._open_file_versions, uri, nothing),
+            " workspace_file=", uri in server._workspace_files,
+            " from_disc=", from_disc,
+            " in_workspace=", in_workspace)
+        if in_workspace
+            st = JuliaWorkspaces.get_text_file(server.workspace, uri).content
+            print(io, " content_bytes=", sizeof(st.content), " line_count=", length(st.line_indices))
+            if from_disc
+                # `true` means the workspace holds the on-disc text rather than
+                # an editor buffer, e.g. after didClose reverted the document.
+                print(io, " serving_disc_copy=", server._files_from_disc[uri].content.content == st.content)
+            end
+        end
+        return String(take!(io))
+    catch err
+        # Collecting context must never mask the error being reported.
+        return "context unavailable: $(sprint(showerror, err))"
+    end
+end
+
 function invoke_handler(func, params, server::LanguageServerInstance, conn)
     try
         if USE_REVISE[] && isdefined(Main, :Revise)
@@ -179,9 +215,19 @@ function invoke_handler(func, params, server::LanguageServerInstance, conn)
             return func(params, server, conn)
         end
     catch err
-        err isa MissingDocumentError || rethrow()
-        @debug "Handler $(nameof(func)) targeted a document not in the server" uri = err.uri
-        return JSONRPC.JSONRPCError(-32602, "Document not available: $(err.uri).", nothing)
+        if err isa MissingDocumentError
+            @debug "Handler $(nameof(func)) targeted a document not in the server" uri = err.uri
+            return JSONRPC.JSONRPCError(-32602, "Document not available: $(err.uri).", nothing)
+        elseif err isa LSOffsetError
+            # Re-raise with the document sync state attached so the crash
+            # report can explain why the server's text disagreed with the
+            # client's position. `rethrow(e)` keeps the original backtrace, so
+            # the report still shows the `index_at` frame that threw.
+            uri = hasproperty(params, :textDocument) && hasproperty(params.textDocument, :uri) ? params.textDocument.uri : nothing
+            rethrow(LSOffsetError(string(err.msg, "\nhandler=", nameof(func), "\n", document_sync_context(server, uri))))
+        else
+            rethrow()
+        end
     end
 end
 

--- a/src/requests/textdocument.jl
+++ b/src/requests/textdocument.jl
@@ -75,7 +75,7 @@ function textDocument_didSave_notification(params::DidSaveTextDocumentParams, se
             println(stderr, "========== BEGIN CLIENT SIDE TEXT ==========")
             println(stderr, params.text)
             println(stderr, "========== END CLIENT SIDE TEXT ==========")
-            throw(LSSyncMismatch("Mismatch between server and client text for $(uri). _open_in_editor is $(haskey(server._open_file_versions, uri)). _workspace_file is $(uri in server._workspace_files). _version is $(get(server._open_file_versions, uri, 0))."))
+            throw(LSSyncMismatch("Mismatch between server and client text for $(uri). $(document_sync_context(server, uri))"))
         end
     end
 end

--- a/src/textdocument.jl
+++ b/src/textdocument.jl
@@ -13,11 +13,11 @@ function index_at(st::JuliaWorkspaces.SourceText, line::Integer, character::Inte
     text = st.content
 
     if line >= length(line_indices)
-        forgiving_mode || throw(LSOffsetError("index_at crashed. More diagnostics:\nline=$line\nline_indices='$line_indices'"))
+        forgiving_mode || throw(LSOffsetError("index_at crashed. More diagnostics:\nline=$line\nline_count=$(length(line_indices))\ncontent_bytes=$(sizeof(text))\nline_indices='$line_indices'"))
 
         return nextind(text, lastindex(text))
     elseif line < 0
-        throw(LSOffsetError("index_at crashed. More diagnostics:\nline=$line\nline_indices='$line_indices'"))
+        throw(LSOffsetError("index_at crashed. More diagnostics:\nline=$line\nline_count=$(length(line_indices))\ncontent_bytes=$(sizeof(text))\nline_indices='$line_indices'"))
     end
 
     line_index = line_indices[line + 1]

--- a/test/requests/test_request_handling.jl
+++ b/test/requests/test_request_handling.jl
@@ -38,6 +38,85 @@ end
     closetestdoc()
 end
 
+@testitem "documentHighlight past EOF reports document sync context" setup=[TestSetup, SharedServer] begin
+    settestdoc("x = 1")
+
+    # A position on a line the server's text does not have. This still crashes
+    # the server (that is deliberate: it is a sync bug we want reported), but
+    # the crash message must carry enough state to explain the mismatch.
+    params = LanguageServer.DocumentHighlightParams(
+        LanguageServer.TextDocumentIdentifier(uri"untitled:testdoc"),
+        LanguageServer.Position(1, 0),
+        missing,
+        missing,
+    )
+    wrapped = LanguageServer.request_wrapper(LanguageServer.textDocument_documentHighlight_request, server)
+    err = try
+        wrapped(server.jr_endpoint, params, missing)
+        nothing
+    catch e
+        e
+    end
+    @test err isa LanguageServer.LSOffsetError
+    msg = sprint(showerror, err)
+    @test occursin("index_at crashed", msg)
+    @test occursin("handler=textDocument_documentHighlight_request", msg)
+    @test occursin("scheme=untitled", msg)
+    @test occursin("open=true", msg)
+    @test occursin("version=0", msg)
+    @test occursin("line_count=1", msg)
+    @test occursin("from_disc=false", msg)
+
+    closetestdoc()
+end
+
+@testitem "LSOffsetError reports when the workspace serves the disc copy" setup=[TestSetup, SharedServer] begin
+    u = uri"untitled:testdoc"
+    settestdoc("x = 1\ny = 2")
+
+    # Pretend the document also exists on disc with fewer lines, then close it:
+    # didClose reverts the workspace to the disc copy, so a request at a line
+    # that only the editor buffer had must report `serving_disc_copy=true`.
+    server._files_from_disc[u] = LanguageServer.JuliaWorkspaces.TextFile(u, LanguageServer.JuliaWorkspaces.SourceText("x = 1", "julia"))
+    closetestdoc()
+    @test LanguageServer.jw_text(server, u) == "x = 1"
+
+    params = LanguageServer.DocumentHighlightParams(
+        LanguageServer.TextDocumentIdentifier(u),
+        LanguageServer.Position(1, 0),
+        missing,
+        missing,
+    )
+    wrapped = LanguageServer.request_wrapper(LanguageServer.textDocument_documentHighlight_request, server)
+    err = try
+        wrapped(server.jr_endpoint, params, missing)
+        nothing
+    catch e
+        e
+    end
+    @test err isa LanguageServer.LSOffsetError
+    msg = sprint(showerror, err)
+    @test occursin("open=false", msg)
+    @test occursin("from_disc=true", msg)
+    @test occursin("serving_disc_copy=true", msg)
+
+    delete!(server._files_from_disc, u)
+    LanguageServer.JuliaWorkspaces.remove_file!(server.workspace, u)
+end
+
+@testitem "document_sync_context handles unknown and missing URIs" setup=[TestSetup, SharedServer] begin
+    using LanguageServer.URIs2
+
+    unknown_uri = URIs2.URI("vscode-notebook-cell", nothing, "/c:/foo/bar.ipynb", nothing, "X23sZmlsZQ==")
+    ctx = LanguageServer.document_sync_context(server, unknown_uri)
+    @test occursin("scheme=vscode-notebook-cell", ctx)
+    @test occursin("open=false", ctx)
+    @test occursin("in_workspace=false", ctx)
+    @test !occursin("line_count", ctx)
+
+    @test LanguageServer.document_sync_context(server, nothing) == "uri=<unavailable>"
+end
+
 @testitem "editor pid monitoring (#1379)" setup=[TestSetup, SharedServer] begin
     # No editor pid known → no monitor task.
     server.editor_pid = nothing


### PR DESCRIPTION
## Crash signature

Insiders telemetry shows `LanguageServer.LSOffsetError: index_at crashed` from `textDocument/documentHighlight`, with a request at line 54 against a server text whose `line_indices` has 53 entries.

## Why this instead of #1468

#1468 attributes the crash to a failed `didChange` leaving the server text stale, and converts every `LSOffsetError` into a `ContentModified` response. That analysis does not match the crash path: a failed `didChange` throws a plain exception, `JSONRPC.dispatch_msg` rethrows it for notifications, the dispatch loop in `Base.run` has no try/catch, and the extension's launcher catches it and exits the process through `global_err_handler`. No stale state survives. #1468 would also swallow offset errors thrown inside `didChange` itself, hiding exactly the sync bugs we want reported.

Message ordering, line-ending counting, file-watcher and folder events, indirect-file promotion and notebook cells were all checked and cannot produce a server text shorter than the editor buffer. The one remaining candidate is `didClose` reverting a document to its on-disc copy followed by a request for that URI, but the current report has no fields that could confirm or refute it.

## Change

- `document_sync_context(server, uri)` summarises the sync state as `key=value` pairs: URI scheme, open state, version, workspace/disc tracking, byte and line counts, and `serving_disc_copy`, which directly tests the `didClose` hypothesis. Only the scheme is included, never the full URI, so no file paths reach crash telemetry.
- `invoke_handler` re-raises `LSOffsetError` with the handler name and that summary appended, using `rethrow(e)` so the original backtrace (including the `index_at` frame) is preserved. The server still crashes, as before.
- `index_at` messages now also include `line_count` and `content_bytes`.
- The `LSSyncMismatch` message reuses the same summary instead of its hand-rolled tail.

## Testing

- Three new test items in `test/requests/test_request_handling.jl`: documentHighlight past EOF reports the context fields; a document reverted to a shorter disc copy on close reports `serving_disc_copy=true`; unknown and missing URIs are handled.
- All 9 items in `test/requests/test_request_handling.jl` and `test/requests/test_textdocument.jl` pass.
- Verified separately that `rethrow(e)` with a new exception object keeps the original frames in `catch_backtrace()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
